### PR TITLE
Restore checking for undifferentiated headings

### DIFF
--- a/rdfToSolr/src/main/java/edu/cornell/library/integration/indexer/utilities/AuthorityData.java
+++ b/rdfToSolr/src/main/java/edu/cornell/library/integration/indexer/utilities/AuthorityData.java
@@ -24,14 +24,14 @@ public class AuthorityData {
 
 		Connection conn = config.getDatabaseConnection("Headings");
 		PreparedStatement isAuthorizedStmt = conn.prepareStatement(
-				"SELECT main_entry, id FROM heading WHERE type_desc = ? AND sort = ?");
+				"SELECT main_entry, id, undifferentiated FROM heading WHERE type_desc = ? AND sort = ?");
 		isAuthorizedStmt.setInt(1, htd.ordinal());
 		isAuthorizedStmt.setString(2, getFilingForm(heading));
 		ResultSet rs = isAuthorizedStmt.executeQuery();
 		while (rs.next()) {
 			authorized = rs.getBoolean(1);
 			headingId = rs.getInt(2);
-	//		undifferentiated = rs.getBoolean(3);
+			undifferentiated = rs.getBoolean(3);
 		}
 		rs.close();
 		isAuthorizedStmt.close();


### PR DESCRIPTION
This was disabled for compatibility with an older headings table that
didn't have the undifferentiated column.

https://github.com/cul-it/da-solr/commit/6ca0ac6b057d5ec706b67a1dc495ea6642bae16d