### PR TITLE
Avoid duplicate relator term display

### DIFF
--- a/src/main/java/edu/cornell/library/integration/indexer/resultSetToFields/AuthorTitleResultSetToFields.java
+++ b/src/main/java/edu/cornell/library/integration/indexer/resultSetToFields/AuthorTitleResultSetToFields.java
@@ -95,12 +95,12 @@ public class AuthorTitleResultSetToFields implements ResultSetToFields {
 						filing_type = "pers";
 						htd = HeadTypeDesc.PERSNAME;
 					} else if (mainTag.equals("110")) {
-						subfields = "abcdefghijklmnopqrstuvwxyz";
+						subfields = "abcdfghijklmnopqrstuvwxyz";
 						ctsSubfields = "ab";
 						filing_type = "corp";
 						htd = HeadTypeDesc.CORPNAME;
 					} else {
-						subfields = "abcdefghijklmnopqrstuvwxyz";
+						subfields = "abcdefghiklmnopqrstuvwxyz";
 						ctsSubfields = "abe";
 						filing_type = "event";
 						htd = HeadTypeDesc.EVENT;


### PR DESCRIPTION
The relators are populated separately into the display fields, so
pulling them in advance is a mistake.

DISCOVERYACCESS-2578