### PR TITLE
Fix extended indexing day browse updates block

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -124,6 +124,7 @@ task (step09IndexHeadings, dependsOn: 'assemble', type: JavaExec){
    description="Indexes unauthorized headings and record counts based on Blacklight Solr index" 
    main='edu.cornell.library.integration.indexer.IndexHeadings'
    maxHeapSize = '3000m'
+   args = [ 2, 20 ] // fail if launched before 2 am or after 8 pm
    classpath = sourceSets.main.runtimeClasspath
 }
 task (step10Headings2Solr, dependsOn: 'assemble', type: JavaExec){

--- a/solr/blacklightCore/conf/solrconfig.xml
+++ b/solr/blacklightCore/conf/solrconfig.xml
@@ -74,12 +74,12 @@
          Lucene will flush based on whichever limit is hit first.  -->
     <!-- <ramBufferSizeMB>100</ramBufferSizeMB> -->
     <!-- <maxBufferedDocs>1000</maxBufferedDocs> -->
-
+<!--
 	<mergePolicy class="org.apache.solr.index.TieredMergePolicy">
 		<int name="maxMergeAtOnce">10</int>
 		<int name="segmentsPerTier">10</int>
 	</mergePolicy>
-
+-->
     <!-- 
     <mergeFactor>10</mergeFactor>
       -->

--- a/src/main/java/edu/cornell/library/integration/indexer/IndexHeadings.java
+++ b/src/main/java/edu/cornell/library/integration/indexer/IndexHeadings.java
@@ -74,12 +74,12 @@ public class IndexHeadings {
 			int currentHour = Calendar.getInstance().get(Calendar.HOUR_OF_DAY);
 			try {
 				int minHour = Integer.parseInt(args[0]);
-				if (minHour < currentHour)
+				if (minHour > currentHour)
 					throw new IllegalStateException("Error: according to provided arguments, "
 							+ "this method can't be run before "+minHour+":00 local time.");
 				if (args.length > 1) {
 					int maxHour = Integer.parseInt(args[1]);
-					if (maxHour >= currentHour)
+					if (maxHour <= currentHour)
 						throw new IllegalStateException("Error: according to provided arguments, "
 								+ "this method can't be run after "+maxHour+":00 local time.");
 				}


### PR DESCRIPTION
On extended indexing days, the browse index updates should not happen. The original block was ineffective, but this one works better.