### PR TITLE
Reduce priority of title link re-indexes

### DIFF
--- a/src/main/java/edu/cornell/library/integration/indexer/documentPostProcess/UpdateSolrInventoryDB.java
+++ b/src/main/java/edu/cornell/library/integration/indexer/documentPostProcess/UpdateSolrInventoryDB.java
@@ -108,7 +108,7 @@ public class UpdateSolrInventoryDB implements DocumentPostProcess{
 		PreparedStatement markBibForUpdateStmt = conn.prepareStatement(
 				"INSERT INTO "+CurrentDBTable.QUEUE.toString()
 				+ " (bib_id, priority, cause) VALUES"
-				+ " (?, 0, '"+DataChangeUpdateType.TITLELINK.toString()+"')");
+				+ " (?, 1, '"+DataChangeUpdateType.TITLELINK.toString()+"')");
 		Map<Integer,TitleMatchReference> refs = new HashMap<Integer,TitleMatchReference>();
 		TitleMatchReference thisTitle = null;
 		SolrInputField workidDisplay = new SolrInputField("workid_display");
@@ -501,7 +501,7 @@ public class UpdateSolrInventoryDB implements DocumentPostProcess{
 		PreparedStatement markBibForUpdateStmt = conn.prepareStatement(
 				"INSERT INTO "+CurrentDBTable.QUEUE.toString()
 				+ " (bib_id, priority, cause) VALUES"
-				+ " (?, 0, '"+DataChangeUpdateType.TITLELINK.toString()+"')");
+				+ " (?, 1, '"+DataChangeUpdateType.TITLELINK.toString()+"')");
 
 		for (int oclcId : oclcIds) {
 			findWorksForOclcIdStmt.setInt(1, oclcId);
@@ -572,7 +572,7 @@ public class UpdateSolrInventoryDB implements DocumentPostProcess{
 		PreparedStatement markBibForUpdateStmt = conn.prepareStatement(
 				"INSERT INTO "+CurrentDBTable.QUEUE.toString()
 				+ " (bib_id, priority, cause) VALUES"
-				+ " (?, 0, '"+DataChangeUpdateType.TITLELINK.toString()+"')");
+				+ " (?, 1, '"+DataChangeUpdateType.TITLELINK.toString()+"')");
 		for (int oclcid : removedOclcIds) {
 			updateBibWorkMappingStmt.setInt(1, bibid);
 			updateBibWorkMappingStmt.setInt(2, oclcid);

--- a/src/main/java/edu/cornell/library/integration/indexer/updates/IdentifyChangedRecords.java
+++ b/src/main/java/edu/cornell/library/integration/indexer/updates/IdentifyChangedRecords.java
@@ -569,7 +569,7 @@ public class IdentifyChangedRecords {
 		MFHD_UPDATE("Holdings Record Change",IndexQueuePriority.DATACHANGE),
 		ITEM_UPDATE("Item Record Change",IndexQueuePriority.DATACHANGE),
 		DELETE("Record Deleted or Suppressed",IndexQueuePriority.DATACHANGE),
-		TITLELINK("Title Link Update",IndexQueuePriority.DATACHANGE),
+		TITLELINK("Title Link Update",IndexQueuePriority.CODECHANGE_PRIORITY1),
 		
 		AGE_IN_SOLR("Age of Record in Solr",IndexQueuePriority.NOT_RECENTLY_UPDATED);
 


### PR DESCRIPTION
For batch loads of certain collections, the rate of title link
re-indexing can be very high, clogging the indexing with re-indexes that
change very little in the index. The records that have actually changed
should be re-indexed first.