### PR TITLE
Populate URL fields in Solr with link-specific TOU hooks

### DIFF
--- a/src/main/java/edu/cornell/library/integration/indexer/RecordToDocumentMARC.java
+++ b/src/main/java/edu/cornell/library/integration/indexer/RecordToDocumentMARC.java
@@ -251,12 +251,6 @@ public class RecordToDocumentMARC extends RecordToDocumentBase {
         getHathiLinks(),
 
         new SPARQLFieldMakerImpl().setName("database codes")
-        .addMainStoreQuery("url instructions",
-            "SELECT ?v WHERE {\n"
-                + "  $recordURI$ marcrdf:hasField856 ?f.\n"
-                + "  ?f marcrdf:hasSubfield ?sf.\n"
-                + "  ?sf marcrdf:code \"i\"^^xsd:string.\n"
-                + "  ?sf marcrdf:value ?v. }")
         .addMainStoreQuery("record-level instructions",
             "SELECT ?v WHERE {\n"
                 + "  $recordURI$ marcrdf:hasField899 ?f.\n"

--- a/src/main/java/edu/cornell/library/integration/indexer/resultSetToFields/DBCode.java
+++ b/src/main/java/edu/cornell/library/integration/indexer/resultSetToFields/DBCode.java
@@ -38,20 +38,9 @@ public class DBCode implements ResultSetToFields {
 			if( rs != null){
 				while(rs.hasNext()){
 					QuerySolution sol = rs.nextSolution();
-					
+
 					String instructions = nodeToString(sol.get("v"));
-					if (instructions.contains("dbcode") || instructions.contains("providercode")) {
-						String[] codes = instructions.split(";\\s*");
-						for (String code : codes) {
-							String[] parts = code.split("=",2);
-							if (parts.length == 2)
-								if (parts[0].equals("dbcode")) {
-									dbcodes.add(parts[1]);
-								} else if (parts[0].equals("providercode")) {
-									providercodes.add(parts[1]);
-								}
-						}
-					} else if (instructions.contains("_")) {
+					if (instructions.contains("_")) {
 						String[] codes = instructions.split("_",2);
 						if (codes.length == 2) {
 							providercodes.add(codes[0]);

--- a/src/test/java/edu/cornell/library/integration/indexer/resultSetToFields/URLTest.java
+++ b/src/test/java/edu/cornell/library/integration/indexer/resultSetToFields/URLTest.java
@@ -1,0 +1,110 @@
+package edu.cornell.library.integration.indexer.resultSetToFields;
+
+import static org.junit.Assert.*;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+
+import edu.cornell.library.integration.indexer.MarcRecord;
+import edu.cornell.library.integration.indexer.MarcRecord.FieldSet;
+
+@SuppressWarnings("static-method")
+public class URLTest {
+
+	@Test
+	public void testMultipleAccessWithDifferentTOU() throws IOException { //8637892 DISCOVERYACCESS-2947
+		MarcRecord rec = new MarcRecord();
+		MarcRecord.DataField df = new MarcRecord.DataField(1,"856");
+		df.subfields.add(new MarcRecord.Subfield(1, '3', "Full text available from Ebrary The Arts Subscription Collection"));
+		df.subfields.add(new MarcRecord.Subfield(2, 'i', "ssid=ssj0000907852; dbcode=AAGPP; providercode=PRVAHD"));
+		df.subfields.add(new MarcRecord.Subfield(3, 'u', "http://proxy.library.cornell.edu/login?url=http://site.ebrary.com/lib/cornell/Top?id=10657875"));
+		df.subfields.add(new MarcRecord.Subfield(4, 'z', "Connect to text."));
+		rec.dataFields.add(df);
+		df = new MarcRecord.DataField(2,"856");
+		df.subfields.add(new MarcRecord.Subfield(1, '3', "Full text available from Safari Technical Books"));
+		df.subfields.add(new MarcRecord.Subfield(2, 'i', "ssid=ssj0000907852; dbcode=DRU; providercode=PRVPQU"));
+		df.subfields.add(new MarcRecord.Subfield(3, 'u', "http://proxy.library.cornell.edu/login?url=http://proquest.safaribooksonline.com/9781118529669"));
+		df.subfields.add(new MarcRecord.Subfield(4, 'z', "Connect to text."));
+		rec.dataFields.add(df);
+		List<URL.SolrField> allSolrFields = new ArrayList<>();
+		for (FieldSet fs : rec.matchAndSortDataFields()) {
+			URL.SolrFieldValueSet vals = URL.generateSolrFields(fs);
+			allSolrFields.addAll(vals.fields);
+		}
+		assertEquals(6, allSolrFields.size());
+		assertEquals("url_access_display",allSolrFields.get(0).fieldName);
+		assertEquals("notes_t",           allSolrFields.get(1).fieldName);
+		assertEquals("url_access_json",   allSolrFields.get(2).fieldName);
+		assertEquals("url_access_display",allSolrFields.get(3).fieldName);
+		assertEquals("notes_t",           allSolrFields.get(4).fieldName);
+		assertEquals("url_access_json",   allSolrFields.get(5).fieldName);
+		assertEquals("http://proxy.library.cornell.edu/login?url=http://site.ebrary.com/lib/cornell/Top?id=10657875"
+				+ "|Full text available from Ebrary The Arts Subscription Collection Connect to text.",
+				allSolrFields.get(0).fieldValue);
+		assertEquals("Full text available from Ebrary The Arts Subscription Collection Connect to text.",
+				allSolrFields.get(1).fieldValue);
+		assertEquals("{\"providercode\":\"PRVAHD\",\"dbcode\":\"AAGPP\","
+				+ "\"description\":\"Full text available from Ebrary The Arts Subscription Collection Connect to text.\","
+				+ "\"url\":\"http://proxy.library.cornell.edu/login?url=http://site.ebrary.com/lib/cornell/Top?id=10657875\"}",
+				allSolrFields.get(2).fieldValue);
+		assertEquals("http://proxy.library.cornell.edu/login?url=http://proquest.safaribooksonline.com/9781118529669"
+				+ "|Full text available from Safari Technical Books Connect to text.",
+				allSolrFields.get(3).fieldValue);
+		assertEquals("Full text available from Safari Technical Books Connect to text.",
+				allSolrFields.get(4).fieldValue);
+		assertEquals("{\"providercode\":\"PRVPQU\",\"dbcode\":\"DRU\","
+				+ "\"description\":\"Full text available from Safari Technical Books Connect to text.\","
+				+ "\"url\":\"http://proxy.library.cornell.edu/login?url=http://proquest.safaribooksonline.com/9781118529669\"}",
+				allSolrFields.get(5).fieldValue);
+	}
+
+	@Test
+	public void testNoTOU() throws IOException {
+		MarcRecord rec = new MarcRecord();
+		MarcRecord.DataField df = new MarcRecord.DataField(1,"856");
+		df.subfields.add(new MarcRecord.Subfield(1, '3', "Full text available from Ebrary The Arts Subscription Collection"));
+		df.subfields.add(new MarcRecord.Subfield(3, 'u', "http://proxy.library.cornell.edu/login?url=http://site.ebrary.com/lib/cornell/Top?id=10657875"));
+		df.subfields.add(new MarcRecord.Subfield(4, 'z', "Connect to text."));
+		rec.dataFields.add(df);
+		List<URL.SolrField> allSolrFields = new ArrayList<>();
+		for (FieldSet fs : rec.matchAndSortDataFields()) {
+			URL.SolrFieldValueSet vals = URL.generateSolrFields(fs);
+			allSolrFields.addAll(vals.fields);
+		}
+		assertEquals(3, allSolrFields.size());
+		assertEquals("url_access_display",allSolrFields.get(0).fieldName);
+		assertEquals("notes_t",           allSolrFields.get(1).fieldName);
+		assertEquals("url_access_json",   allSolrFields.get(2).fieldName);
+		assertEquals("http://proxy.library.cornell.edu/login?url=http://site.ebrary.com/lib/cornell/Top?id=10657875"
+				+ "|Full text available from Ebrary The Arts Subscription Collection Connect to text.",
+				allSolrFields.get(0).fieldValue);
+		assertEquals("Full text available from Ebrary The Arts Subscription Collection Connect to text.",
+				allSolrFields.get(1).fieldValue);
+		assertEquals("{\"description\":\"Full text available from Ebrary The Arts Subscription Collection Connect to text.\","
+				+ "\"url\":\"http://proxy.library.cornell.edu/login?url=http://site.ebrary.com/lib/cornell/Top?id=10657875\"}",
+				allSolrFields.get(2).fieldValue);
+	}
+	@Test
+	public void testJustURL() throws IOException {
+		MarcRecord rec = new MarcRecord();
+		MarcRecord.DataField df = new MarcRecord.DataField(1,"856");
+		df.subfields.add(new MarcRecord.Subfield(1, 'u', "http://proxy.library.cornell.edu/login?url=http://site.ebrary.com/lib/cornell/Top?id=10657875"));
+		rec.dataFields.add(df);
+		List<URL.SolrField> allSolrFields = new ArrayList<>();
+		for (FieldSet fs : rec.matchAndSortDataFields()) {
+			URL.SolrFieldValueSet vals = URL.generateSolrFields(fs);
+			allSolrFields.addAll(vals.fields);
+		}
+		assertEquals(2, allSolrFields.size());
+		assertEquals("url_access_display",allSolrFields.get(0).fieldName);
+		assertEquals("url_access_json",   allSolrFields.get(1).fieldName);
+		assertEquals("http://proxy.library.cornell.edu/login?url=http://site.ebrary.com/lib/cornell/Top?id=10657875",
+				allSolrFields.get(0).fieldValue);
+		assertEquals("{\"url\":\"http://proxy.library.cornell.edu/login?url=http://site.ebrary.com/lib/cornell/Top?id=10657875\"}",
+				allSolrFields.get(1).fieldValue);
+	}
+
+}


### PR DESCRIPTION
The new field url_access_json is intended to replace the
url_access_display Solr field. It has four component fields. "url" and
"description" mirror information previously available in the
url_access_display, while the new, optional, "dbcode" and "providercode"
fields will be populated with link-specific TOU hooks where available.
The "description" argument will also be unpopulated when no description
is available for the link.

The root-level Solr fields, "dbcode" and "providercode" will continue to
be populated, but only with the codes that appear in record-level 899
fields, not the link-specific ones that appear in 856 fields.

DISCOVERYACCESS-2947