### PR TITLE
Include SSID in url_access_json

### DIFF
--- a/src/main/java/edu/cornell/library/integration/indexer/resultSetToFields/URL.java
+++ b/src/main/java/edu/cornell/library/integration/indexer/resultSetToFields/URL.java
@@ -65,11 +65,7 @@ public class URL implements ResultSetToFields {
 			for (String code : codes) {
 				String[] parts = code.split("=",2);
 				if (parts.length == 2)
-					if (parts[0].equals("dbcode")) {
-						jsonModel.put("dbcode",parts[1]);
-					} else if (parts[0].equals("providercode")) {
-						jsonModel.put("providercode",parts[1]);
-					}
+					jsonModel.put(parts[0].toLowerCase(), parts[1]);
 			}
 		}
 


### PR DESCRIPTION
Rather than add explicit support for ssid, I will simplify the logic by
not enforcing the set of allowable fields to be imported into the json.
The first time, enforcing the set of fields caused problems when a new
field was added that we didn't know about. The risk of occassionally
pulling in erroneous fields seems modest and not destructive if it did
occur.

DISCOVERYACCESS-3438