### PR TITLE
Limit 041 language codes displayed in item view

### DIFF
--- a/src/main/java/edu/cornell/library/integration/indexer/resultSetToFields/Language.java
+++ b/src/main/java/edu/cornell/library/integration/indexer/resultSetToFields/Language.java
@@ -90,9 +90,14 @@ public class Language implements ResultSetToFields {
 						if ( c.equals(Code.UND) || c.equals(Code.ZXX)
 								|| vals.display.contains(c.getLanguageName()))
 							continue;
-						vals.display.add(c.getLanguageName());
-						if ("adegj".contains(sf.code.toString()))
+						switch (sf.code) {
+						// subfields for faceting and display
+						case 'a': case 'd': case 'e': case 'g': case 'j':
 							vals.facet.add(c.getLanguageName());
+						// subfields for display only
+						case 'b': case 'f':
+							vals.display.add(c.getLanguageName());
+						}
 					}
 				}
 			}

--- a/src/test/java/edu/cornell/library/integration/indexer/resultSetToFields/LanguageTest.java
+++ b/src/test/java/edu/cornell/library/integration/indexer/resultSetToFields/LanguageTest.java
@@ -115,4 +115,19 @@ public class LanguageTest {
 		assertEquals("In Hindi with English subtitles.",vals.notes.iterator().next());
 	}
 
+	@Test
+	public void testSubfieldFiltering() {
+		MarcRecord rec = new MarcRecord();
+		MarcRecord.DataField f = new MarcRecord.DataField(3,"041");
+		f.subfields.add(new MarcRecord.Subfield(1, 'a', "hin")); // display & facet
+		f.subfields.add(new MarcRecord.Subfield(2, 'b', "eng")); // display only
+		f.subfields.add(new MarcRecord.Subfield(3, 'h', "spa")); // neither
+		rec.dataFields.add(f);
+		Language.SolrFieldValueSet vals = Language.generateSolrFields ( rec );
+		assertEquals(1,               vals.facet.size());
+		assertEquals("Hindi",         String.join(", ",vals.facet));
+		assertEquals(2,               vals.display.size());
+		assertEquals("Hindi, English",String.join(", ",vals.display));
+		assertEquals(0,               vals.notes.size());
+	}
 }


### PR DESCRIPTION
Per DISCOVERYACCESS-3404, language codes for the language of an original
version of a work do not necessarily represent the language of the item
described. The languages identified for the table of contents and
summary/abstract are still displayed but not included in the facet.
Hopefully this doesn't come up often enough to cause confusion, but in a
future iteration we may consider displaying annotations with the
languages to represent their role in the work.