### PR TITLE
Streamline population of subject search fields

### DIFF
--- a/src/main/java/edu/cornell/library/integration/indexer/RecordToDocumentMARC.java
+++ b/src/main/java/edu/cornell/library/integration/indexer/RecordToDocumentMARC.java
@@ -279,18 +279,6 @@ public class RecordToDocumentMARC extends RecordToDocumentBase {
             "SELECT (SUBSTR(?l,7,2) as ?char67) WHERE { $recordURI$ marcrdf:leader ?l. }")
         .addResultSetToFields(new FactOrFiction()),
 
-        // subject_t is essentially a boost field. Should eventually be dropped or
-        // population moved to SubjectRSTF.
-        new StandardMARCFieldMaker("subject_t", "600", "abcdefghijklmnopqrstu", VernMode.SEARCH),
-        new StandardMARCFieldMaker("subject_t", "610", "abcdefghijklmnopqrstu", VernMode.SEARCH),
-        new StandardMARCFieldMaker("subject_t", "611", "abcdefghijklmnopqrstu", VernMode.SEARCH),
-        new StandardMARCFieldMaker("subject_t", "630", "abcdefghijklmnopqrst", VernMode.SEARCH),
-        new StandardMARCFieldMaker("subject_t", "650", "abcde", VernMode.SEARCH),
-        new StandardMARCFieldMaker("subject_t", "651", "ae", VernMode.SEARCH),
-        new StandardMARCFieldMaker("subject_t", "653", "a", VernMode.SEARCH),
-        new StandardMARCFieldMaker("subject_t", "654", "abcde", VernMode.SEARCH),
-        new StandardMARCFieldMaker("subject_t", "655", "abc", VernMode.SEARCH),
-
         new SPARQLFieldMakerImpl().setName("subject")
         .addMainStoreQuery("subjects", standardDataFieldGroupSPARQL("marcrdf:SubjectTermEntry"))
         .addResultSetToFields(new Subject()),

--- a/src/main/java/edu/cornell/library/integration/indexer/resultSetToFields/Subject.java
+++ b/src/main/java/edu/cornell/library/integration/indexer/resultSetToFields/Subject.java
@@ -243,7 +243,7 @@ public class Subject implements ResultSetToFields {
 
 			for (final String s: values880_breadcrumbed) {
 				final String disp = removeTrailingPunctuation(s,".");
-				ResultSetUtilities.addField(fields,"subject_addl_t",s);
+				ResultSetUtilities.addField(fields,"subject_t",s);
 				if (h.isFAST)
 					ResultSetUtilities.addField(fields,"fast_"+facet_type+"_facet",disp);
 				if ( ! h.isFAST || ! recordHasLCSH)
@@ -251,7 +251,7 @@ public class Subject implements ResultSetToFields {
 			}
 			for (final String s: valuesMain_breadcrumbed) {
 				final String disp = removeTrailingPunctuation(s,".");
-				ResultSetUtilities.addField(fields,"subject_addl_t",s);
+				ResultSetUtilities.addField(fields,"subject_t",s);
 				if (h.isFAST || (h.isLCGFT && facet_type.equals("genre")))
 					ResultSetUtilities.addField(fields,"fast_"+facet_type+"_facet",disp);
 				if ( ! h.isFAST || ! recordHasLCSH)


### PR DESCRIPTION
We don't really need separate fields for subject_t and subject_addl_t,
and the current implementation is resulting in nine extra
StandardMARCFieldMakers being created for every processed bib. Since
these are a major cause of inefficiency in the code base, I hope for a
minor speed boost to come from this change.