### PR TITLE
Display pub info subfield $3

### DIFF
--- a/src/main/java/edu/cornell/library/integration/indexer/solrFieldGen/PubInfo.java
+++ b/src/main/java/edu/cornell/library/integration/indexer/solrFieldGen/PubInfo.java
@@ -125,7 +125,7 @@ public class PubInfo implements ResultSetToFields {
 				default: relation = INFORMATION;
 				}
 			for (DataField df : fs.getFields()) {
-				sfs.fields.add(new SolrField(relation,df.concatenateSpecificSubfields("abc")));
+				sfs.fields.add(new SolrField(relation,df.concatenateSpecificSubfields("3abc")));
 				if (relation.equals(INFORMATION) || relation.equals(COPYRIGHT))
 					for (Subfield sf : df.subfields)
 						if (sf.code.equals('c'))


### PR DESCRIPTION
The 260$3 and 264$3 are important context to display as part of
publication information. Their inclusion was dropped by commit
346048ad241ad54cb637447774adfb6918937c5d on May 8th (merged to prod May
31st).