### PR TITLE
Exclude non-TOU 856$i values from TOU field extraction

### DIFF
--- a/src/main/java/edu/cornell/library/integration/indexer/solrFieldGen/URL.java
+++ b/src/main/java/edu/cornell/library/integration/indexer/solrFieldGen/URL.java
@@ -27,7 +27,7 @@ public class URL implements SolrFieldGenerator {
 	private static ObjectMapper mapper = new ObjectMapper();
 
 	@Override
-	public String getVersion() { return "1.2"; }
+	public String getVersion() { return "1.3"; }
 
 	@Override
 	public List<String> getHandledFields() { return Arrays.asList("856","holdings"); }
@@ -48,12 +48,12 @@ public class URL implements SolrFieldGenerator {
 			Map<String,Object> processedLink = new HashMap<>();
 
 			List<String> urls = f.valueListForSpecificSubfields("u");
-			String instructions = f.concatenateSpecificSubfields("i");
+			List<String> instructions = f.valueListForSpecificSubfields("i");
 			String linkLabel = f.concatenateSpecificSubfields("3yz");
 
-			if (instructions != null &&
-					(instructions.contains("dbcode") || instructions.contains("providercode"))) {
-				String[] codes = instructions.split(";\\s*");
+			for (String instruction : instructions)
+			if (instruction.contains("dbcode") || instruction.contains("providercode")) {
+				String[] codes = instruction.split(";\\s*");
 				for (String code : codes) {
 					String[] parts = code.split("=",2);
 					if (parts.length == 2 && ! parts[1].equals("?"))

--- a/src/test/java/edu/cornell/library/integration/indexer/solrFieldGen/URLTest.java
+++ b/src/test/java/edu/cornell/library/integration/indexer/solrFieldGen/URLTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertEquals;
 import java.io.IOException;
 import java.sql.SQLException;
 
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import edu.cornell.library.integration.marc.DataField;
@@ -13,6 +14,14 @@ import edu.cornell.library.integration.marc.MarcRecord;
 public class URLTest {
 
 	SolrFieldGenerator gen = new URL();
+	static MarcRecord online ;
+
+	@BeforeClass
+	public static void createServRemoHolding() {
+		online = new MarcRecord(MarcRecord.RecordType.HOLDINGS);
+		online.id = "1";
+		online.dataFields.add(new DataField(1,"852",' ',' ',"‡b serv,remo"));
+	}
 
 	@Test   //8637892 DISCOVERYACCESS-2947
 	public void testMultipleAccessWithDifferentTOU() throws IOException, ClassNotFoundException, SQLException {
@@ -25,10 +34,7 @@ public class URLTest {
 				"‡3 Full text available from Safari Technical Books ‡i ssid=ssj0000907852; dbcode=DRU;"
 				+ " providercode=PRVPQU ‡u http://proxy.library.cornell.edu/login?"
 				+ "url=http://proquest.safaribooksonline.com/9781118529669 ‡z Connect to text."));
-		MarcRecord holdings = new MarcRecord(MarcRecord.RecordType.HOLDINGS);
-		holdings.id = "1";
-		holdings.dataFields.add(new DataField(1,"852",' ',' ',"‡b serv,remo"));
-		rec.holdings.add(holdings);
+		rec.holdings.add(online);
 		String expected =
 		"url_access_display: http://proxy.library.cornell.edu/login?url=http://site.ebrary.com/lib/"
 		+ "cornell/Top?id=10657875|Full text available from Ebrary The Arts Subscription Collection"
@@ -57,10 +63,7 @@ public class URLTest {
 				"‡3 Full text available from Ebrary The Arts Subscription Collection ‡u"
 				+ " http://proxy.library.cornell.edu/login?url=http://site.ebrary.com/lib/cornell/Top?"
 				+ "id=10657875 ‡z Connect to text."));
-		MarcRecord holdings = new MarcRecord(MarcRecord.RecordType.HOLDINGS);
-		holdings.id = "1";
-		holdings.dataFields.add(new DataField(1,"852",' ',' ',"‡b serv,remo"));
-		rec.holdings.add(holdings);
+		rec.holdings.add(online);
 		String expected =
 		"url_access_display: http://proxy.library.cornell.edu/login?url=http://site.ebrary.com/lib/cornell/Top?"
 		+ "id=10657875|Full text available from Ebrary The Arts Subscription Collection Connect to text.\n"+
@@ -85,10 +88,7 @@ public class URLTest {
 	@Test
 	public void testJustURL() throws IOException, ClassNotFoundException, SQLException {
 		MarcRecord rec = new MarcRecord(MarcRecord.RecordType.BIBLIOGRAPHIC);
-		MarcRecord holdings = new MarcRecord(MarcRecord.RecordType.HOLDINGS);
-		holdings.id = "1";
-		holdings.dataFields.add(new DataField(1,"852",' ',' ',"‡b serv,remo"));
-		rec.holdings.add(holdings);
+		rec.holdings.add(online);
 		rec.dataFields.add(new DataField(1,"856",'4','0',
 				"‡u http://proxy.library.cornell.edu/login?url=http://site.ebrary.com/lib/cornell/Top?id=10657875"));
 		String expected =
@@ -124,10 +124,7 @@ public class URLTest {
 		"‡i dbcode=JTX; providercode=PRVAWR "+
 		"‡u http://proxy.library.cornell.edu/login?url=https://www.taylorfrancis.com/books/e/9781466552609 "+
 		"‡z Full text is available via download of individual chapter PDFs; scroll down for full table of contents."));
-		MarcRecord holdingRec = new MarcRecord(MarcRecord.RecordType.HOLDINGS);
-		holdingRec.id = "1";
-		holdingRec.dataFields.add(new DataField(1,"852",' ',' ',"‡b serv,remo"));
-		bibRec.holdings.add(holdingRec);
+		bibRec.holdings.add(online);
 		String expected =
 		"url_access_display: http://proxy.library.cornell.edu/login?url=https://www.taylorfrancis.com/books/e/"
 		+  "9781466552609|Full text is available via download of individual chapter PDFs; scroll down for full"
@@ -168,10 +165,7 @@ public class URLTest {
 		"‡3 Available from the U.S. Government Printing Office. "+
 		"‡i dbcode=ACAJP; providercode=PRVLSH "+
 		"‡u http://purl.access.gpo.gov/GPO/LPS77292\n"));
-		MarcRecord holdingRec = new MarcRecord(MarcRecord.RecordType.HOLDINGS);
-		holdingRec.id = "1";
-		holdingRec.dataFields.add(new DataField(1,"852",' ',' ',"‡b serv,remo"));
-		bibRec.holdings.add(holdingRec);
+		bibRec.holdings.add(online);
 		String expected =
 		"url_other_display: http://www.loc.gov/catdir/enhancements/fy0667/2006046631-t.html|"
 		+ "Available from the U.S. Government Printing Office. Table of contents only\n" + 
@@ -182,6 +176,27 @@ public class URLTest {
 		"url_access_json: {\"providercode\":\"PRVLSH\",\"dbcode\":\"ACAJP\",\"description\":"
 		+ "\"Available from the U.S. Government Printing Office.\","
 		+ "\"url\":\"http://purl.access.gpo.gov/GPO/LPS77292\"}\n" + 
+		"online: Online\n";
+		assertEquals( expected, gen.generateSolrFields(bibRec, null).toString() );
+	}
+
+
+	@Test
+	public void nonTOUUseOf856i() throws IOException, ClassNotFoundException, SQLException {
+		MarcRecord bibRec = new MarcRecord(MarcRecord.RecordType.BIBLIOGRAPHIC);
+		bibRec.id = "10204686";
+		bibRec.dataFields.add(new DataField(1,"856",'7',' ',
+		"‡3 Available from the U.S. Government Printing Office "+
+		"‡i Archived issues "+
+		"‡i dbcode=ACAJP; providercode=PRVLSH "+
+		"‡u https://purl.fdlp.gov/GPO/gpo86434"));
+		bibRec.holdings.add(online);
+		String expected =
+		"url_access_display: https://purl.fdlp.gov/GPO/gpo86434|Available from the U.S. Government Printing Office\n" + 
+		"notes_t: Available from the U.S. Government Printing Office\n" + 
+		"url_access_json: {\"providercode\":\"PRVLSH\",\"dbcode\":\"ACAJP\","
+		+ "\"description\":\"Available from the U.S. Government Printing Office\","
+		+ "\"url\":\"https://purl.fdlp.gov/GPO/gpo86434\"}\n" + 
 		"online: Online\n";
 		assertEquals( expected, gen.generateSolrFields(bibRec, null).toString() );
 	}


### PR DESCRIPTION
So far it looks like mostly GPO links that are including both the $i TOU data, identifying dbcode, providercode, and sometimes a $i field like "Archived issues" or "2017 Issue" that seems like it might better belong in a $z. Though these are likely intended for display, I'm not sure how dependable that judgement would be, so I'm just making sure that they don't interfere with the TOU field extraction for now.

DISCOVERYACCESS-5149