### PR TITLE
Create discogs_display field for discogs identifiers DISCOVERYACCESS-6490

### DIFF
--- a/src/main/java/edu/cornell/library/integration/metadata/generator/OtherIDs.java
+++ b/src/main/java/edu/cornell/library/integration/metadata/generator/OtherIDs.java
@@ -21,10 +21,13 @@ public class OtherIDs implements SolrFieldGenerator {
 	public SolrFields generateSolrFields( MarcRecord rec, Config config ) {
 		SolrFields sfs = new SolrFields();
 		for (DataField f : rec.dataFields) {
-			boolean isDoi = false;
+			String knownVocab = null;
 			for (Subfield sf : f.subfields)
-				if ( sf.code.equals('2') && sf.value.trim().equals("doi") )
-					isDoi = true;
+				if ( sf.code.equals('2') )
+					switch ( sf.value.trim() ) {
+					case "doi": knownVocab = "doi"; break;
+					case "discogs": knownVocab = "discogs"; break;
+					}
 
 			for (Subfield sf : f.subfields) if (sf.code.equals('a')) {
 
@@ -40,8 +43,8 @@ public class OtherIDs implements SolrFieldGenerator {
 				case "035":
 					if (sf.value.startsWith("(OCoLC)"))
 						sfs.add(new SolrField("oclc_id_display",sf.value.substring(7).trim()));
-					else if ( isDoi )
-						sfs.add(new SolrField("doi_display",sf.value));
+					else if ( knownVocab != null )
+						sfs.add(new SolrField(knownVocab+"_display",sf.value));
 					else
 						sfs.add(new SolrField("other_id_display",sf.value));
 					break;

--- a/src/test/java/edu/cornell/library/integration/metadata/generator/OtherIDsTest.java
+++ b/src/test/java/edu/cornell/library/integration/metadata/generator/OtherIDsTest.java
@@ -45,4 +45,14 @@ public class OtherIDsTest {
 		assertEquals(expected,this.gen.generateSolrFields(rec,null).toString());
 	}
 
+	@Test
+	public void testDiscogs() throws ClassNotFoundException, SQLException, IOException {
+		MarcRecord rec = new MarcRecord(MarcRecord.RecordType.BIBLIOGRAPHIC);
+		rec.dataFields.add(new DataField(1,"024",'7',' ',"‡a test id value ‡2 discogs"));
+		String expected =
+		"id_t: test id value\n" + 
+		"discogs_display: test id value\n";
+		assertEquals(expected,this.gen.generateSolrFields(rec,null).toString());
+	}
+
 }


### PR DESCRIPTION
DISCOVERYACCESS-6490

(I am deliberately not incrementing the version of this code. There are no discogs displayed populated in Voyager so far, so there's no need to trigger rerunning of this code against records that haven't changed. Once in production, the new code will take effect for any records that do change.)