### PR TITLE
Improve new HathiLinks query

### DIFF
--- a/src/main/java/edu/cornell/library/integration/metadata/generator/HathiLinks.java
+++ b/src/main/java/edu/cornell/library/integration/metadata/generator/HathiLinks.java
@@ -89,7 +89,7 @@ public class HathiLinks implements SolrFieldGenerator {
 			Map<String,Collection<String>> etasMaterials = new HashMap<>();
 			int etasVolumeCount = 0;
 			try (  PreparedStatement pstmt = conn.prepareStatement
-					("SELECT b.Volume_Identifier, b.UofM_Record_Number, overlap.rights"
+					("SELECT distinct b.Volume_Identifier, b.UofM_Record_Number, overlap.rights"
 					+ " FROM overlap, raw_hathi, raw_hathi b"
 					+" WHERE overlap.bib_id = ?"
 					+ "  AND overlap.ht_id = raw_hathi.Volume_Identifier"


### PR DESCRIPTION
The query as written returned a lot of duplicate records for some titles, and in an extreme case crashed the program.