### PR TITLE
Improve regex for extracting user limits from 899

### DIFF
--- a/src/main/java/edu/cornell/library/integration/metadata/generator/URL.java
+++ b/src/main/java/edu/cornell/library/integration/metadata/generator/URL.java
@@ -175,7 +175,7 @@ public class URL implements SolrFieldGenerator {
 
 		return sfs;
 	}
-	private static Pattern userLimit899 = Pattern.compile("^.*[A-Za-z](\\d+)u$");
+	private static Pattern userLimit899 = Pattern.compile("^.*[A-Za-z_~](\\d+)u$");
 	private static Pattern number = Pattern.compile("^\\d+$");
 
 	private static void reassignOtherLinksToAccess(List<Map<String, Object>> allProcessedLinks) {

--- a/src/test/java/edu/cornell/library/integration/metadata/generator/URLTest.java
+++ b/src/test/java/edu/cornell/library/integration/metadata/generator/URLTest.java
@@ -31,7 +31,6 @@ public class URLTest {
 		"‡y Click here to find online versions of this title. "+
 		"‡u https://search.ebscohost.com/login.aspx?CustID=s9001366&db=edspub&type=44&"
 		+ "bQuery=AN%202471499&direct=true&site=pfi-live"));
-		rec.dataFields.add(new DataField(2,"899",' ',' ',"‡a ebraryebks3u"));
 		rec.holdings.add(online);
 		String expected =
 		"ebsco_title_facet: 2471499\n" + 
@@ -40,12 +39,55 @@ public class URLTest {
 		+ "\"titleid\":\"2471499\","
 		+ "\"description\":\"Click here to find online versions of this title.\","
 		+ "\"url\":\"https://search.ebscohost.com/login.aspx?CustID=s9001366&db=edspub&type=44&"
-		+           "bQuery=AN%202471499&direct=true&site=pfi-live\","
-		+ "\"users\":3}\n" + 
+		+           "bQuery=AN%202471499&direct=true&site=pfi-live\"}\n" + 
 		"online: Online\n";
 		assertEquals( expected, this.gen.generateSolrFields(rec, null).toString() );
 	}
 
+	@Test
+	public void userLimitsIn899() throws ClassNotFoundException, SQLException, IOException {
+		{
+			MarcRecord rec = new MarcRecord(MarcRecord.RecordType.BIBLIOGRAPHIC);
+			rec.id = "9298323";
+			rec.dataFields.add(new DataField(1,"856",'4','0',
+					"‡u http://proxy.library.cornell.edu/login"
+					+ "?url=http://site.ebrary.com/lib/cornell/docDetail.action?docID=11113926 "+
+					"‡z Connect to full text"));
+			rec.dataFields.add(new DataField(2,"899",' ',' ',"‡a ebraryebks3u"));
+			rec.holdings.add(online);
+			String expected = 
+			"notes_t: Connect to full text\n" + 
+			"url_access_json: {"
+			+ "\"description\":\"Connect to full text\","
+			+ "\"url\":\"http://proxy.library.cornell.edu/login?url="
+			+           "http://site.ebrary.com/lib/cornell/docDetail.action?docID=11113926\","
+			+ "\"users\":3}\n" + 
+			"online: Online\n";
+			assertEquals( expected, this.gen.generateSolrFields(rec, null).toString() );
+		}
+		{
+			MarcRecord rec = new MarcRecord(MarcRecord.RecordType.BIBLIOGRAPHIC);
+			rec.id = "10821629";
+			rec.dataFields.add(new DataField(1,"856",'4','0',
+					"‡3 Available from Brepols "+
+					"‡i dbcode=~9u; providercode=PRVBRP "+
+					"‡u http://proxy.library.cornell.edu/login?"
+					+     "url=http://www.brepolsonline.net/doi/book/10.1484/M.CURSOR-EB.6.09070802050003050302020604 "+
+					"‡z Connect to full text."));
+			rec.dataFields.add(new DataField(2,"899",'2',' ',"‡a PRVBRP_~9u"));
+			rec.holdings.add(online);
+			String expected =
+			"notes_t: Available from Brepols Connect to full text.\n"+
+			"url_access_json: {"
+			+  "\"providercode\":\"PRVBRP\",\"dbcode\":\"~9u\","
+			+  "\"description\":\"Available from Brepols Connect to full text.\","
+			+  "\"url\":\"http://proxy.library.cornell.edu/login?"
+			+            "url=http://www.brepolsonline.net/doi/book/10.1484/M.CURSOR-EB.6.09070802050003050302020604\","
+			+  "\"users\":9}\n"+
+			"online: Online\n";
+			assertEquals( expected, this.gen.generateSolrFields(rec, null).toString() );
+		}
+	}
 
 	@Test   //8637892 DISCOVERYACCESS-2947
 	public void testMultipleAccessWithDifferentTOU() throws IOException, ClassNotFoundException, SQLException {


### PR DESCRIPTION
DISCOVERYACCESS-6931
Expecting 899 values to be largely alphanumeric, my original regex didn't isolate the 9u from PRVBRP_~9u.