### PR TITLE
Add vocabulary-specific subject facets for authorities management

### DIFF
--- a/src/main/java/edu/cornell/library/integration/metadata/generator/Subject.java
+++ b/src/main/java/edu/cornell/library/integration/metadata/generator/Subject.java
@@ -45,7 +45,7 @@ public class Subject implements SolrFieldGenerator {
 	private static List<String> unwantedFacetValues = Arrays.asList("Electronic books");
 
 	@Override
-	public String getVersion() { return "2.3"; }
+	public String getVersion() { return "2.4"; }
 
 	@Override
 	public List<String> getHandledFields() {
@@ -113,12 +113,12 @@ public class Subject implements SolrFieldGenerator {
 			taggedFields.add(h);
 		}
 		for( final Heading h : taggedFields) {
-			final Set<String> values880_breadcrumbed = new HashSet<>();
-			final Set<String> valuesMain_breadcrumbed = new HashSet<>();
+			final Set<String> values880_breadcrumbed = new LinkedHashSet<>();
+			final Set<String> valuesMain_breadcrumbed = new LinkedHashSet<>();
 			final List<BrowseValue> values_browse = new ArrayList<>();
-			final Set<String> valuesMain_json = new HashSet<>();
-			final Set<String> values880_json = new HashSet<>();
-			final Set<String> values_dashed = new HashSet<>();
+			final Set<String> valuesMain_json = new LinkedHashSet<>();
+			final Set<String> values880_json = new LinkedHashSet<>();
+			final Set<String> values_dashed = new LinkedHashSet<>();
 			HeadingType ht = HeadingType.GENHEAD; //default
 
 			String main_fields = null, dashed_fields = "", facet_type = "topic";
@@ -279,13 +279,14 @@ public class Subject implements SolrFieldGenerator {
 					}
 
 					// tabulate subdivision sequences
-					for ( int i = 0 ; i < dashed_terms.size(); i++ ) {
-						String s = dashed_terms.get(i);
-						values_dashed.add(getFilingForm(s));
-						for ( int j = i + 1 ; j < dashed_terms.size(); j++) {
-							s += " > "+dashed_terms.get(j);
-							values_dashed.add(getFilingForm(s));
-						}
+					if ( ! is880 )
+						for ( int i = 0 ; i < dashed_terms.size(); i++ ) {
+							String s = dashed_terms.get(i);
+							values_dashed.add(s);
+							for ( int j = i + 1 ; j < dashed_terms.size(); j++) {
+								s += " > "+dashed_terms.get(j);
+								values_dashed.add(s);
+							}
 					}
 				}
 			}
@@ -319,12 +320,17 @@ public class Subject implements SolrFieldGenerator {
 					String filing = getFilingForm(value.display);
 					sfs.add(new SolrField("subject_"+ht.abbrev()+"_filing",filing));
 					String canonFiling = getFilingForm(value.canon);
-					if ( ! value.is880 )
-						sfs.add(new SolrField("subject_"+ht.abbrev()
-						+"_"+h.vocab.name().toLowerCase()+"_filing",canonFiling));
+					if ( ! value.is880 ) {
+						String vocab = h.vocab.name().toLowerCase();
+						sfs.add(new SolrField("subject_"+ht.abbrev()+"_"+vocab+"_facet", value.canon));
+						sfs.add(new SolrField("subject_"+ht.abbrev()+"_"+vocab+"_filing",canonFiling));
+					}
 				}
-			for (final String s: values_dashed)
-				sfs.add(new SolrField("subject_sub_"+h.vocab.name().toLowerCase()+"_filing",s));
+			for (final String s: values_dashed) {
+				String vocab = h.vocab.name().toLowerCase();
+				sfs.add(new SolrField("subject_sub_"+vocab+"_facet", removeTrailingPunctuation(s,".")));
+				sfs.add(new SolrField("subject_sub_"+vocab+"_filing",getFilingForm(s)));
+			}
 
 			if ( ! h.is653 && ( ! h.vocab.equals(HeadingVocab.FAST) || ! recordHasLCSH ) ) {
 				for (final String s: values880_json)

--- a/src/test/java/edu/cornell/library/integration/metadata/generator/SubjectTest.java
+++ b/src/test/java/edu/cornell/library/integration/metadata/generator/SubjectTest.java
@@ -33,10 +33,13 @@ public class SubjectTest {
 		"subject_t: Submerged lands > United States\n"+
 		"subject_topic_facet: Submerged lands\n"+
 		"subject_topic_filing: submerged lands\n"+
+		"subject_topic_lc_facet: Submerged lands\n"+
 		"subject_topic_lc_filing: submerged lands\n"+
 		"subject_topic_facet: Submerged lands > United States\n"+
 		"subject_topic_filing: submerged lands 0000 united states\n"+
+		"subject_topic_lc_facet: Submerged lands > United States\n"+
 		"subject_topic_lc_filing: submerged lands 0000 united states\n"+
+		"subject_sub_lc_facet: United States\n"+
 		"subject_sub_lc_filing: united states\n"+
 		"subject_json: [{\"subject\":\"Submerged lands\",\"authorized\":true,\"type\":\"Topical Term\"},"
 		+ "{\"subject\":\"United States.\",\"authorized\":false}]\n"+
@@ -58,15 +61,19 @@ public class SubjectTest {
 		"subject_t: Submerged lands > United States\n"+
 		"subject_topic_facet: Submerged lands\n"+
 		"subject_topic_filing: submerged lands\n"+
+		"subject_topic_lc_facet: Submerged lands\n"+
 		"subject_topic_lc_filing: submerged lands\n"+
 		"subject_topic_facet: Submerged lands > United States\n"+
 		"subject_topic_filing: submerged lands 0000 united states\n"+
+		"subject_topic_lc_facet: Submerged lands > United States\n"+
 		"subject_topic_lc_filing: submerged lands 0000 united states\n"+
+		"subject_sub_lc_facet: United States\n"+
 		"subject_sub_lc_filing: united states\n"+
 		"subject_t: Submerged lands\n"+
 		"fast_topic_facet: Submerged lands\n"+
 		"subject_topic_facet: Submerged lands\n"+
 		"subject_topic_filing: submerged lands\n"+
+		"subject_topic_fast_facet: Submerged lands\n"+
 		"subject_topic_fast_filing: submerged lands\n"+
 		"subject_json: [{\"subject\":\"Submerged lands\",\"authorized\":true,\"type\":\"Topical Term\"},"
 		+ "{\"subject\":\"United States.\",\"authorized\":false}]\n"+
@@ -88,6 +95,7 @@ public class SubjectTest {
 		"fast_era_facet: 2000 - 2099\n"+
 		"subject_era_facet: 2000-2099\n"+
 		"subject_era_filing: 2000 2099\n"+
+		"subject_era_fast_facet: 2000-2099\n"+
 		"subject_era_fast_filing: 2000 2099\n"+
 		"subject_json: [{\"subject\":\"2000-2099\",\"authorized\":false,\"type\":\"Chronological Term\"}]\n"+
 		"subject_display: 2000 - 2099\n"+
@@ -104,6 +112,7 @@ public class SubjectTest {
 		"fast_era_facet: 1900 - 1999\n" + 
 		"subject_era_facet: 1900 - 1999\n" + 
 		"subject_era_filing: 1900 1999\n" +
+		"subject_era_fast_facet: 1900 - 1999\n" + 
 		"subject_era_fast_filing: 1900 1999\n" +
 		"subject_json: [{\"subject\":\"1900 - 1999\",\"authorized\":false,\"type\":\"Chronological Term\"}]\n" + 
 		"subject_display: 1900 - 1999\n" + 
@@ -120,6 +129,7 @@ public class SubjectTest {
 		"subject_t: Jesuits. Congregatio Generalis (32nd : 1974-1975 : Rome, Italy). | Decree Four\n"+
 		"subject_work_facet: Jesuits. Congregatio Generalis (32nd : 1974-1975 : Rome, Italy). | Decree Four\n"+
 		"subject_work_filing: jesuits congregatio generalis 32nd 1974 1975 rome italy 0000 decree four\n"+
+		"subject_work_lc_facet: Jesuits. Congregatio Generalis (32nd : 1974-1975 : Rome, Italy). | Decree Four\n"+
 		"subject_work_lc_filing: jesuits congregatio generalis 32nd 1974 1975 rome italy 0000 decree four\n"+
 		"subject_json: [{\"subject\":\"Jesuits. Congregatio Generalis (32nd : 1974-1975 : Rome, Italy). | Decree Four.\",\"authorized\":true,\"type\":\"Work\"}]\n"+
 		"subject_display: Jesuits. Congregatio Generalis (32nd : 1974-1975 : Rome, Italy). | Decree Four\n"+
@@ -134,6 +144,7 @@ public class SubjectTest {
 		"subject_t: Bible. | Paraphrases. O.T. English\n"+
 		"subject_work_facet: Bible. | Paraphrases. O.T. English\n"+
 		"subject_work_filing: bible 0000 paraphrases ot english\n"+
+		"subject_work_lc_facet: Bible. | Paraphrases. O.T. English\n"+
 		"subject_work_lc_filing: bible 0000 paraphrases ot english\n"+
 		"subject_json: [{\"subject\":\"Bible. | Paraphrases. O.T. English.\","
 		+ "\"authorized\":false,\"type\":\"Work\"}]\n"+
@@ -156,10 +167,13 @@ public class SubjectTest {
 		"subject_corp_filing: 朝日新聞 0000 indexes\n"+
 		"subject_corp_facet: Asahi Shinbun\n"+
 		"subject_corp_filing: asahi shinbun\n"+
+		"subject_corp_lc_facet: Asahi Shinbun\n"+
 		"subject_corp_lc_filing: asahi shinbun\n"+
 		"subject_corp_facet: Asahi Shinbun > Indexes\n"+
 		"subject_corp_filing: asahi shinbun 0000 indexes\n"+
+		"subject_corp_lc_facet: Asahi Shinbun > Indexes\n"+
 		"subject_corp_lc_filing: asahi shinbun 0000 indexes\n"+
+		"subject_sub_lc_facet: Indexes\n"+
 		"subject_sub_lc_filing: indexes\n"+
 		"subject_json: [{\"subject\":\"朝日新聞\",\"authorized\":false,\"type\":\"Corporate Name\"},"
 		+ "{\"subject\":\"Indexes.\",\"authorized\":false}]\n"+
@@ -178,6 +192,7 @@ public class SubjectTest {
 		String expected =
 		"subject_t: Electronic books\n"+
 		"subject_topic_filing: electronic books\n"+
+		"subject_topic_unk_facet: Electronic books\n"+
 		"subject_topic_unk_filing: electronic books\n"+
 		"subject_json: [{\"subject\":\"Electronic books.\",\"authorized\":true,\"type\":\"Topical Term\"}]\n"+
 		"subject_display: Electronic books\n"+
@@ -199,6 +214,7 @@ public class SubjectTest {
 		"subject_t: Textiles and Fashion Design\n"+
 		"subject_gen_facet: Textiles and Fashion Design\n"+
 		"subject_gen_filing: textiles and fashion design\n"+
+		"subject_gen_unk_facet: Textiles and Fashion Design\n"+
 		"subject_gen_unk_filing: textiles and fashion design\n"+
 		"keyword_display: Textiles and Fashion Design\n"+
 		"fast_b: false\n";
@@ -211,12 +227,13 @@ public class SubjectTest {
 		MarcRecord rec = new MarcRecord(MarcRecord.RecordType.BIBLIOGRAPHIC);
 		rec.dataFields.add(new DataField(1,"653",' ',' ',"‡a Art and Architecture (Core)"));
 		String expected =
-		"sixfivethree: Art and Architecture (Core)\n" + 
-		"subject_t: Art and Architecture (Core)\n" + 
-		"subject_gen_facet: Art and Architecture\n" + 
-		"subject_gen_filing: art and architecture\n" + 
+		"sixfivethree: Art and Architecture (Core)\n" +
+		"subject_t: Art and Architecture (Core)\n" +
+		"subject_gen_facet: Art and Architecture\n" +
+		"subject_gen_filing: art and architecture\n" +
+		"subject_gen_unk_facet: Art and Architecture\n" +
 		"subject_gen_unk_filing: art and architecture\n" +
-		"keyword_display: Art and Architecture\n" + 
+		"keyword_display: Art and Architecture\n" +
 		"fast_b: false\n";
 		assertEquals(expected,this.gen.generateSolrFields(rec, config).toString());
 	}
@@ -248,104 +265,141 @@ public class SubjectTest {
 		"subject_t: Undocumented immigrants > United States\n" + 
 		"subject_topic_facet: Undocumented immigrants\n" + 
 		"subject_topic_filing: undocumented immigrants\n" + 
+		"subject_topic_lc_facet: Illegal aliens\n" + 
 		"subject_topic_lc_filing: illegal aliens\n" + 
 		"subject_topic_facet: Undocumented immigrants > United States\n" +
 		"subject_topic_filing: undocumented immigrants 0000 united states\n" + 
+		"subject_topic_lc_facet: Illegal aliens > United States\n" + 
 		"subject_topic_lc_filing: illegal aliens 0000 united states\n" + 
+		"subject_sub_lc_facet: United States\n"+
 		"subject_sub_lc_filing: united states\n"+
 
 		"subject_t: Undocumented immigrants > Government policy > United States\n" + 
 		"subject_topic_facet: Undocumented immigrants\n" + 
-		"subject_topic_filing: undocumented immigrants\n" + 
+		"subject_topic_filing: undocumented immigrants\n" +
+		"subject_topic_lc_facet: Illegal aliens\n" + 
 		"subject_topic_lc_filing: illegal aliens\n" + 
 		"subject_topic_facet: Undocumented immigrants > Government policy\n" + 
-		"subject_topic_filing: undocumented immigrants 0000 government policy\n" + 
+		"subject_topic_filing: undocumented immigrants 0000 government policy\n" +
+		"subject_topic_lc_facet: Illegal aliens > Government policy\n" + 
 		"subject_topic_lc_filing: illegal aliens 0000 government policy\n" + 
 		"subject_topic_facet: Undocumented immigrants > Government policy > United States\n" + 
 		"subject_topic_filing: undocumented immigrants 0000 government policy 0000 united states\n" + 
-		"subject_topic_lc_filing: illegal aliens 0000 government policy 0000 united states\n" + 
+		"subject_topic_lc_facet: Illegal aliens > Government policy > United States\n" +
+		"subject_topic_lc_filing: illegal aliens 0000 government policy 0000 united states\n" +
+		"subject_sub_lc_facet: Government policy\n"+
 		"subject_sub_lc_filing: government policy\n"+
+		"subject_sub_lc_facet: Government policy > United States\n"+
 		"subject_sub_lc_filing: government policy 0000 united states\n"+
+		"subject_sub_lc_facet: United States\n"+
 		"subject_sub_lc_filing: united states\n"+
 
 		"subject_t: Undocumented immigrant children > United States\n" + 
 		"subject_topic_facet: Undocumented immigrant children\n" + 
 		"subject_topic_filing: undocumented immigrant children\n" + 
+		"subject_topic_lc_facet: Illegal alien children\n" + 
 		"subject_topic_lc_filing: illegal alien children\n" + 
 		"subject_topic_facet: Undocumented immigrant children > United States\n" + 
-		"subject_topic_filing: undocumented immigrant children 0000 united states\n" + 
-		"subject_topic_lc_filing: illegal alien children 0000 united states\n" + 
+		"subject_topic_filing: undocumented immigrant children 0000 united states\n" +
+		"subject_topic_lc_facet: Illegal alien children > United States\n" +
+		"subject_topic_lc_filing: illegal alien children 0000 united states\n" +
+		"subject_sub_lc_facet: United States\n"+
 		"subject_sub_lc_filing: united states\n"+
 
 		"subject_t: Undocumented immigrant children > Government policy > United States\n" + 
 		"subject_topic_facet: Undocumented immigrant children\n" + 
 		"subject_topic_filing: undocumented immigrant children\n" + 
+		"subject_topic_lc_facet: Illegal alien children\n" + 
 		"subject_topic_lc_filing: illegal alien children\n" + 
 		"subject_topic_facet: Undocumented immigrant children > Government policy\n" + 
 		"subject_topic_filing: undocumented immigrant children 0000 government policy\n" + 
-		"subject_topic_lc_filing: illegal alien children 0000 government policy\n" + 
+		"subject_topic_lc_facet: Illegal alien children > Government policy\n" +
+		"subject_topic_lc_filing: illegal alien children 0000 government policy\n" +
 		"subject_topic_facet: Undocumented immigrant children > Government policy > United States\n" + 
 		"subject_topic_filing: undocumented immigrant children 0000 government policy 0000 united states\n" + 
+		"subject_topic_lc_facet: Illegal alien children > Government policy > United States\n" + 
 		"subject_topic_lc_filing: illegal alien children 0000 government policy 0000 united states\n" + 
+		"subject_sub_lc_facet: Government policy\n"+
 		"subject_sub_lc_filing: government policy\n"+
+		"subject_sub_lc_facet: Government policy > United States\n"+
 		"subject_sub_lc_filing: government policy 0000 united states\n"+
+		"subject_sub_lc_facet: United States\n"+
 		"subject_sub_lc_filing: united states\n"+
 
 		"subject_t: United States > Emigration and immigration > Government policy\n" + 
-		"subject_topic_facet: United States\n" + 
-		"subject_topic_filing: united states\n" + 
-		"subject_topic_lc_filing: united states\n" + 
+		"subject_topic_facet: United States\n" +
+		"subject_topic_filing: united states\n" +
+		"subject_topic_lc_facet: United States\n" +
+		"subject_topic_lc_filing: united states\n" +
 		"subject_topic_facet: United States > Emigration and immigration\n" + 
 		"subject_topic_filing: united states 0000 emigration and immigration\n" + 
+		"subject_topic_lc_facet: United States > Emigration and immigration\n" + 
 		"subject_topic_lc_filing: united states 0000 emigration and immigration\n" + 
 		"subject_topic_facet: United States > Emigration and immigration > Government policy\n" + 
 		"subject_topic_filing: united states 0000 emigration and immigration 0000 government policy\n" + 
+		"subject_topic_lc_facet: United States > Emigration and immigration > Government policy\n" + 
 		"subject_topic_lc_filing: united states 0000 emigration and immigration 0000 government policy\n" + 
-		"subject_sub_lc_filing: emigration and immigration 0000 government policy\n"+
-		"subject_sub_lc_filing: government policy\n"+
+		"subject_sub_lc_facet: Emigration and immigration\n"+
 		"subject_sub_lc_filing: emigration and immigration\n"+
+		"subject_sub_lc_facet: Emigration and immigration > Government policy\n"+
+		"subject_sub_lc_filing: emigration and immigration 0000 government policy\n"+
+		"subject_sub_lc_facet: Government policy\n"+
+		"subject_sub_lc_filing: government policy\n"+
 
 
 		"subject_t: Emigration and immigration law > United States\n" + 
-		"subject_topic_facet: Emigration and immigration law\n" + 
-		"subject_topic_filing: emigration and immigration law\n" + 
-		"subject_topic_lc_filing: emigration and immigration law\n" + 
+		"subject_topic_facet: Emigration and immigration law\n" +
+		"subject_topic_filing: emigration and immigration law\n" +
+		"subject_topic_lc_facet: Emigration and immigration law\n" +
+		"subject_topic_lc_filing: emigration and immigration law\n"+ 
 		"subject_topic_facet: Emigration and immigration law > United States\n" + 
 		"subject_topic_filing: emigration and immigration law 0000 united states\n" + 
+		"subject_topic_lc_facet: Emigration and immigration law > United States\n" + 
 		"subject_topic_lc_filing: emigration and immigration law 0000 united states\n" + 
+		"subject_sub_lc_facet: United States\n"+
 		"subject_sub_lc_filing: united states\n"+
 
-		"subject_t: POLITICAL SCIENCE > American Government\n" + 
-		"subject_topic_facet: POLITICAL SCIENCE\n" + 
-		"subject_topic_filing: political science\n" + 
-		"subject_topic_other_filing: political science\n" + 
-		"subject_topic_facet: POLITICAL SCIENCE > American Government\n" + 
-		"subject_topic_filing: political science 0000 american government\n" + 
-		"subject_topic_other_filing: political science 0000 american government\n" + 
+		"subject_t: POLITICAL SCIENCE > American Government\n"+ 
+		"subject_topic_facet: POLITICAL SCIENCE\n" +
+		"subject_topic_filing: political science\n" +
+		"subject_topic_other_facet: POLITICAL SCIENCE\n" +
+		"subject_topic_other_filing: political science\n"+ 
+		"subject_topic_facet: POLITICAL SCIENCE > American Government\n"+ 
+		"subject_topic_filing: political science 0000 american government\n"+ 
+		"subject_topic_other_facet: POLITICAL SCIENCE > American Government\n"+ 
+		"subject_topic_other_filing: political science 0000 american government\n"+ 
+		"subject_sub_other_facet: American Government\n"+
 		"subject_sub_other_filing: american government\n"+
 
-		"subject_t: Undocumented immigrants > United States\n" + 
-		"subject_topic_facet: Undocumented immigrants\n" + 
+		"subject_t: Undocumented immigrants > United States\n" +
+		"subject_topic_facet: Undocumented immigrants\n" +
 		"subject_topic_filing: undocumented immigrants\n" + 
+		"subject_topic_other_facet: Illegal aliens\n" + 
 		"subject_topic_other_filing: illegal aliens\n" + 
 		"subject_topic_facet: Undocumented immigrants > United States\n" + 
 		"subject_topic_filing: undocumented immigrants 0000 united states\n" + 
+		"subject_topic_other_facet: Illegal aliens > United States\n" + 
 		"subject_topic_other_filing: illegal aliens 0000 united states\n" + 
+		"subject_sub_other_facet: United States\n"+
 		"subject_sub_other_filing: united states\n"+
 
 		"subject_t: Immigration law > United States\n" + 
 		"subject_topic_facet: Immigration law\n" + 
-		"subject_topic_filing: immigration law\n" + 
+		"subject_topic_filing: immigration law\n" +
+		"subject_topic_unk_facet: Immigration law\n" + 
 		"subject_topic_unk_filing: immigration law\n" + 
 		"subject_topic_facet: Immigration law > United States\n" + 
 		"subject_topic_filing: immigration law 0000 united states\n" + 
+		"subject_topic_unk_facet: Immigration law > United States\n" + 
 		"subject_topic_unk_filing: immigration law 0000 united states\n" + 
+		"subject_sub_unk_facet: United States\n"+
 		"subject_sub_unk_filing: united states\n"+
 
 		"subject_t: Undocumented immigrants\n" + 
-		"fast_topic_facet: Undocumented immigrants\n" + 
+		"fast_topic_facet: Undocumented immigrants\n" +
 		"subject_topic_facet: Undocumented immigrants\n" + 
 		"subject_topic_filing: undocumented immigrants\n" + 
+		"subject_topic_fast_facet: Illegal aliens\n" + 
 		"subject_topic_fast_filing: illegal aliens\n" + 
 
 		"subject_json: [{\"subject\":\"Undocumented immigrants\",\"authorized\":true,\"type\":\"Topical Term\"},{\"subject\":\"United States.\",\"authorized\":false}]\n" + 


### PR DESCRIPTION
Also, removing 880 values from the subject_sub_*_filing fields, which should have been done in the previous commit (https://github.com/cul-it/da-solr/commit/c509718f02c697fdf2a4bf899ef04c931ea22fb4)

DISCOVERYACCESS-7439