### PR TITLE
Populate non-880 author browse fields

### DIFF
--- a/src/main/java/edu/cornell/library/integration/metadata/generator/TitleChange.java
+++ b/src/main/java/edu/cornell/library/integration/metadata/generator/TitleChange.java
@@ -28,7 +28,7 @@ import edu.cornell.library.integration.utilities.SolrFields.SolrField;
 public class TitleChange implements SolrFieldGenerator {
 
 	@Override
-	public String getVersion() { return "1.3"; }
+	public String getVersion() { return "1.4"; }
 
 	@Override
 	public List<String> getHandledFields() {

--- a/src/main/java/edu/cornell/library/integration/utilities/NameUtils.java
+++ b/src/main/java/edu/cornell/library/integration/utilities/NameUtils.java
@@ -192,10 +192,20 @@ public class NameUtils {
 				sfs.add(new SolrField((isCJK)?"author_addl_t_cjk":"author_addl_t",ctsVals.author));
 				String authorFacet = NameUtils.facetValue( f );
 				sfs.add(new SolrField("author_facet",NameUtils.getFacetForm(authorFacet)));
-				sfs.add(new SolrField(
-						(f.mainTag.equals("700"))?"author_pers_filing":
-							(f.mainTag.equals("710"))?"author_corp_filing":"author_event_filing",
-						getFilingForm(authorFacet)));
+				String filingAuthorName = getFilingForm(authorFacet);
+				if ( f.mainTag.equals("700") ) {
+					sfs.add(new SolrField("author_pers_filing",filingAuthorName));
+					if ( ! f.tag.equals("880") )
+						sfs.add(new SolrField("author_pers_roman_filing",filingAuthorName));
+				} else if ( f.mainTag.equals("710") ) {
+					sfs.add(new SolrField("author_corp_filing",filingAuthorName));
+					if ( ! f.tag.equals("880") )
+						sfs.add(new SolrField("author_corp_roman_filing",filingAuthorName));
+				} else {
+					sfs.add(new SolrField("author_event_filing",filingAuthorName));
+					if ( ! f.tag.equals("880") )
+						sfs.add(new SolrField("author_event_roman_filing",filingAuthorName));
+				}
 			} else {
 				relation = "related_work_display";
 			}

--- a/src/test/java/edu/cornell/library/integration/metadata/generator/TitleChangeTest.java
+++ b/src/test/java/edu/cornell/library/integration/metadata/generator/TitleChangeTest.java
@@ -73,6 +73,7 @@ public class TitleChangeTest {
 		"author_addl_t: Sallinen, Aulis.\n"+
 		"author_facet: Sallinen, Aulis\n"+
 		"author_pers_filing: sallinen aulis\n"+
+		"author_pers_roman_filing: sallinen aulis\n"+
 		"included_work_display: Sallinen, Aulis. Vintern war hård; arranged.|Vintern war hård; arranged.|"
 		+ "Sallinen, Aulis.\n"+
 		"title_uniform_t: Vintern war hård; arranged.\n"+
@@ -81,6 +82,7 @@ public class TitleChangeTest {
 		"author_addl_t: Riley, Terry, 1935-\n"+
 		"author_facet: Riley, Terry, 1935-\n"+
 		"author_pers_filing: riley terry 1935\n"+
+		"author_pers_roman_filing: riley terry 1935\n"+
 		"included_work_display: Riley, Terry, 1935- Salome dances for peace. Half-wolf dances mad in moonlight.|"
 		+ "Salome dances for peace. Half-wolf dances mad in moonlight.|Riley, Terry, 1935-\n"+
 		"title_uniform_t: Salome dances for peace. Half-wolf dances mad in moonlight.\n"+
@@ -90,6 +92,7 @@ public class TitleChangeTest {
 		"author_addl_t: Barber, Samuel, 1910-1981.\n"+
 		"author_facet: Barber, Samuel, 1910-1981\n"+
 		"author_pers_filing: barber samuel 1910 1981\n"+
+		"author_pers_roman_filing: barber samuel 1910 1981\n"+
 		"included_work_display: Barber, Samuel, 1910-1981. Quartets, violins (2), viola, cello, no. 1, op. 11,"
 		+ " B minor. Adagio.|Quartets, violins (2), viola, cello, no. 1, op. 11, B minor. Adagio.|"
 		+ "Barber, Samuel, 1910-1981.\n"+
@@ -282,6 +285,7 @@ public class TitleChangeTest {
 		"author_addl_t: Vatican Council (2nd : 1962-1965).\n"+
 		"author_facet: Vatican Council\n"+
 		"author_event_filing: vatican council\n"+
+		"author_event_roman_filing: vatican council\n"+
 		"included_work_display: Vatican Council (2nd : 1962-1965). Constitutio pastoralis de ecclesia in"
 		+ " mundo huius temporis Nn. 19-21. English.|Constitutio pastoralis de ecclesia in mundo huius"
 		+ " temporis Nn. 19-21. English.|Vatican Council (2nd : 1962-1965).\n"+


### PR DESCRIPTION
These are internal-use authority control maintenance fields. They are populated now for authors that appear simply as authors, not those that appear as part of an included work.

DISCOVERYACCESS-7439