### PR TITLE
Bug fix for null electronicAccess hash in Folio JSON

### DIFF
--- a/src/main/java/edu/cornell/library/integration/metadata/generator/URL.java
+++ b/src/main/java/edu/cornell/library/integration/metadata/generator/URL.java
@@ -277,7 +277,9 @@ public class URL implements SolrFieldGenerator {
 		if ( ! ArrayList.class.isInstance(record.get("electronicAccess"))) return links;
 		List<Map<String,String>> rawLinks = ArrayList.class.cast(record.get("electronicAccess"));
 		for (Map<String,String> rawLink : rawLinks) {
-			if ( !rawLink.containsKey("uri") || String.class.cast(rawLink.get("uri")).isEmpty())
+			if ( rawLink == null
+					|| !rawLink.containsKey("uri")
+					|| String.class.cast(rawLink.get("uri")).isEmpty())
 				continue;
 			Map<String,Object> processedLink = new HashMap<>();
 			processedLink.put("url", String.class.cast(rawLink.get("uri")));


### PR DESCRIPTION
This was work done for issues DISCOVERYACCESS-7211 and DISCOVERYACCESS-7492. Links in Folio instances and holdings should take the form of an array of hashes. The code was confirming that individual fields exist in the hash before attempting to use them, but was not checking that the hash itself is not null.

This looks like
"electronicAccess":[null]
where it should be structured something like
"electronicAccess": [{"relationshipId": "5bfe1b7b-f151-4501-8cfa-23b321d5cd1e", "uri": "http://plates.library.cornell.edu/donor/DNR00401", "linkText": "", "materialsSpecification": "", "publicNote": "The Jarett F. and Younghee Kim Wait Fund for Korean Literature"}]

 (Empty fields are not required.)