### PR TITLE
Apply URI validation from Folio links (holdings/instances) to 856 links

### DIFF
--- a/src/test/java/edu/cornell/library/integration/metadata/generator/URLTest.java
+++ b/src/test/java/edu/cornell/library/integration/metadata/generator/URLTest.java
@@ -396,4 +396,14 @@ public class URLTest {
 		assertEquals("",this.gen.generateNonMarcSolrFields(instance, null).toString());
 	}
 
+	@Test
+	public void invalidSyntaxInMarcURI() throws IOException, ClassNotFoundException, SQLException {
+		MarcRecord bibRec = new MarcRecord(MarcRecord.RecordType.BIBLIOGRAPHIC);
+		bibRec.id = "123456";
+		bibRec.dataFields.add(new DataField(1,"856",'7',' ',
+		"‡3 Connect to full text. "+
+		"‡u NOT A  LINK"));
+		bibRec.folioHoldings = onlineFolioHoldingList;
+		assertEquals( "", this.gen.generateSolrFields(bibRec, null).toString() );
+	}
 }


### PR DESCRIPTION
The ticket is already resolved, but after conferring about the added validation it was decided that validating across the board makes sense. Any invalid links will be silently skipped but logged.
DISCOVERYACCESS-7492