### PR TITLE
Tweak UI validation

### DIFF
--- a/src/main/java/edu/cornell/library/integration/metadata/generator/URL.java
+++ b/src/main/java/edu/cornell/library/integration/metadata/generator/URL.java
@@ -122,7 +122,7 @@ public class URL implements SolrFieldGenerator {
 			}
 			String url = urls.iterator().next();
 			try { // Use Java URI validation to confirm link
-				URI uri = new URI(selectivelyUrlEncode(url)); //TODO
+				URI uri = new URI(selectivelyUrlEncode(url));
 				if ( uri.getHost() == null ) throw new URISyntaxException(url,"No Host in URL");
 			} catch (URISyntaxException e) {
 				System.out.printf("URISyntaxException %s; Skipping\n",e.getMessage());
@@ -320,7 +320,7 @@ public class URL implements SolrFieldGenerator {
 			String url = String.class.cast(rawLink.get("uri").trim());
 
 			try { // Use Java URI validation to confirm link
-				URI uri = new URI(selectivelyUrlEncode(url)); //TODO
+				URI uri = new URI(selectivelyUrlEncode(url));
 				if ( uri.getHost() == null ) throw new URISyntaxException(url,"No Host in URL");
 			} catch (URISyntaxException e) {
 				System.out.printf("URISyntaxException %s; Skipping\n",e.getMessage());

--- a/src/main/java/edu/cornell/library/integration/metadata/generator/URL.java
+++ b/src/main/java/edu/cornell/library/integration/metadata/generator/URL.java
@@ -2,8 +2,10 @@ package edu.cornell.library.integration.metadata.generator;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -11,6 +13,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -119,7 +122,8 @@ public class URL implements SolrFieldGenerator {
 			}
 			String url = urls.iterator().next();
 			try { // Use Java URI validation to confirm link
-				new URI(url);
+				URI uri = new URI(selectivelyUrlEncode(url)); //TODO
+				if ( uri.getHost() == null ) throw new URISyntaxException(url,"No Host in URL");
 			} catch (URISyntaxException e) {
 				System.out.printf("URISyntaxException %s; Skipping\n",e.getMessage());
 				continue;
@@ -200,6 +204,28 @@ public class URL implements SolrFieldGenerator {
 
 		return sfs;
 	}
+
+	static String selectivelyUrlEncode(String url) {
+		StringBuilder sb = new StringBuilder();
+		for (int i = 0; i < url.length(); i++) {
+			char c = url.charAt(i);
+			if (replacements.containsKey(c))
+				sb.append(replacements.get(c));
+			else
+				sb.append(c);
+		}
+		return sb.toString();
+	}
+	private static String urlEncodedChar(Character c) {
+		try {
+			return URLEncoder.encode(String.valueOf(c),"UTF-8");
+		} catch (UnsupportedEncodingException e) {
+			e.printStackTrace();
+			return String.valueOf(c);
+		}
+	}
+	static Map<Character,String> replacements = Arrays.asList(' ','"','{','}')
+				.stream().collect(Collectors.toMap(c -> c, c -> urlEncodedChar(c) ));
 
 	@Override
 	public SolrFields generateNonMarcSolrFields( Map<String,Object> instance, Config config ) throws IOException {
@@ -291,11 +317,11 @@ public class URL implements SolrFieldGenerator {
 					|| String.class.cast(rawLink.get("uri")).isEmpty())
 				continue;
 			Map<String,Object> processedLink = new HashMap<>();
-			String url = String.class.cast(
-					rawLink.get("uri").replaceAll("\\\\n"," ").replaceAll("\\s+"," ").trim());
+			String url = String.class.cast(rawLink.get("uri").trim());
 
 			try { // Use Java URI validation to confirm link
-				new URI(url);
+				URI uri = new URI(selectivelyUrlEncode(url)); //TODO
+				if ( uri.getHost() == null ) throw new URISyntaxException(url,"No Host in URL");
 			} catch (URISyntaxException e) {
 				System.out.printf("URISyntaxException %s; Skipping\n",e.getMessage());
 				continue;

--- a/src/test/java/edu/cornell/library/integration/metadata/generator/URLTest.java
+++ b/src/test/java/edu/cornell/library/integration/metadata/generator/URLTest.java
@@ -397,13 +397,38 @@ public class URLTest {
 	}
 
 	@Test
-	public void invalidSyntaxInMarcURI() throws IOException, ClassNotFoundException, SQLException {
+	public void syntaxValidationInMarcURI() throws IOException, ClassNotFoundException, SQLException {
 		MarcRecord bibRec = new MarcRecord(MarcRecord.RecordType.BIBLIOGRAPHIC);
 		bibRec.id = "123456";
 		bibRec.dataFields.add(new DataField(1,"856",'7',' ',
 		"‡3 Connect to full text. "+
 		"‡u NOT A  LINK"));
+		bibRec.dataFields.add(new DataField(2,"856",'4','2',//15459111
+		"‡a Rose Goldsen Archive of New Media Art "+
+		"‡u http:// goldsen.library.cornell.edu"));
+		bibRec.dataFields.add(new DataField(3,"856",'4',' ',//15157320
+		"‡3 Image "+ // This one should be okay with selective URL encoding of the brackets {}
+		"‡u https://img1.od-cdn.com/ImageType-100/3082-1/{04999A8F-6BC6-4370-B438-EE0C49D8C921}Img100.jpg"));
+		bibRec.dataFields.add(new DataField(4,"856",'7',' ',
+		"‡3 Connect to full text. "+
+		"‡u http://1.2.3.4/ipaddress-accepted-as-host.html"));
 		bibRec.folioHoldings = onlineFolioHoldingList;
-		assertEquals( "", this.gen.generateSolrFields(bibRec, null).toString() );
+		assertEquals( 
+				"notes_t: Image\n" + 
+				"url_access_json: {\"description\":\"Image\","
+				+ "\"url\":\"https://img1.od-cdn.com/ImageType-100/3082-1/{04999A8F-6BC6-4370-B438-EE0C49D8C921}Img100.jpg\"}\n" + 
+				"notes_t: Connect to full text.\n" + 
+				"url_access_json: {\"description\":\"Connect to full text.\","
+				+ "\"url\":\"http://1.2.3.4/ipaddress-accepted-as-host.html\"}\n"+
+				"online: Online\n",
+				this.gen.generateSolrFields(bibRec, null).toString() );
+	}
+
+	@Test
+	public void encodeURLs() {
+		assertEquals(
+				"http://sunsite2.berkeley.edu:8000/%22target=%22_blank",
+				URL.selectivelyUrlEncode("http://sunsite2.berkeley.edu:8000/\"target=\"_blank"));
+		
 	}
 }


### PR DESCRIPTION
Java's built in URI() contructor does validation, but it appears to have been both too strict in some places and not strict enough in others.

It is flagging links as invalid if they contain spaces, double quotes, or curly brackets, but the links that contains those will still work in a browser as the browser will apply the necessary encodings. As a result, I'm now applying some very careful URL encoding to those characters in an effort not to hide other more problematic issues from the validation.

It also fails to flag values like "NOT A LINK" as invalid links (once the spaces are encoded and not a cause for rejection themselves). I suspect these are accepted because they may potentially be relative links, but we shouldn't have relative links in Folio. As a result, I'm now rejecting any links that don't contain a host component.