### PR TITLE
DISCOVERYACCESS-7392: fix pound sign in ISBN display

### DIFF
--- a/src/main/java/edu/cornell/library/integration/metadata/generator/ISBN.java
+++ b/src/main/java/edu/cornell/library/integration/metadata/generator/ISBN.java
@@ -38,25 +38,28 @@ public class ISBN implements SolrFieldGenerator {
 				if ( sf.value.isEmpty() ) continue;
 				switch (sf.code) {
 				case 'a':
-					// Display values
 					aFound = true;
-					if (sbDisplay.length() > 0)
-						sbDisplay.append(' ');
-					sbDisplay.append(sf.value);
 
-					// Search values
-					String searchISBN ;
+					String cleanedISBN ;
 					int posOfSpace = sf.value.indexOf(' ');
-					if (posOfSpace == -1) searchISBN = sf.value;
-					else searchISBN = sf.value.substring(0, sf.value.indexOf(' '));
-					searchISBN = searchISBN.replaceAll("[^0-9Xx]", "");
-					vals.add(new SolrField( "isbn_t", searchISBN ));
-					boolean valid = validISBN.matcher(searchISBN).matches();
-					if (searchISBN.length() == 10 && valid)
-						vals.add(new SolrField( "isbn_t", isbn10to13(searchISBN) ));
-					else if ( searchISBN.length() == 13 && valid && searchISBN.startsWith("978") )
-						vals.add(new SolrField( "isbn_t", isbn13to10(searchISBN) ));
-					break;
+					if (posOfSpace == -1) cleanedISBN = sf.value;
+					else cleanedISBN = sf.value.substring(0, sf.value.indexOf(' '));
+					cleanedISBN = cleanedISBN.replaceAll("[^0-9Xx]", "");
+					vals.add(new SolrField( "isbn_t", cleanedISBN ));
+					boolean valid = validISBN.matcher(cleanedISBN).matches();
+					if (cleanedISBN.length() == 10 && valid)
+						vals.add(new SolrField( "isbn_t", isbn10to13(cleanedISBN) ));
+					else if ( cleanedISBN.length() == 13 && valid && cleanedISBN.startsWith("978") )
+						vals.add(new SolrField( "isbn_t", isbn13to10(cleanedISBN) ));
+					
+					if (sbDisplay.length() > 0)
+                        sbDisplay.append(' ');
+					if (posOfSpace == -1)
+					    sbDisplay.append(cleanedISBN);
+					else
+					    sbDisplay.append(cleanedISBN).append(sf.value.substring(posOfSpace));
+
+                    break;
 				case 'c':
 					// Not currently displayed
 					break;

--- a/src/test/java/edu/cornell/library/integration/metadata/generator/ISBNTest.java
+++ b/src/test/java/edu/cornell/library/integration/metadata/generator/ISBNTest.java
@@ -183,4 +183,14 @@ public class ISBNTest {
 		assertEquals( "0345391802", ISBN.isbn13to10("9780345391803"));
 	}
 
+	@Test // prune invalid pound sign, may not be valid isbn
+    public void invalidPound() throws ClassNotFoundException, SQLException, IOException {
+        MarcRecord rec = new MarcRecord(MarcRecord.RecordType.BIBLIOGRAPHIC);
+        rec.id = "2009547";
+        rec.dataFields.add(new DataField( 1, "020", ' ',' ',"‡a 0852980450£12.00"));
+        String expected =
+        "isbn_t: 08529804501200\n" + 
+        "isbn_display: 08529804501200\n";
+        assertEquals( expected, this.gen.generateSolrFields ( rec, null ).toString() );
+    }
 }


### PR DESCRIPTION
This update will remove pound symbol (£) from ISBN display when present.