### PR TITLE
Update SRS date processing to match other endpoints

### DIFF
--- a/src/main/java/edu/cornell/library/integration/processing/LDPChangeDetection.java
+++ b/src/main/java/edu/cornell/library/integration/processing/LDPChangeDetection.java
@@ -103,7 +103,7 @@ public class LDPChangeDetection {
 							.replaceAll("\\s*\\n\\s*", " ");
 					Matcher m = modDateP.matcher(marc);
 					Timestamp marcTimestamp = (m.matches())
-							? Timestamp.from(Instant.parse(m.group(1).replace("+0000","Z"))): null;
+							? Timestamp.from(Instant.parse(m.group(1).replace("+00:00","Z"))): null;
 					cacheReplaceStmt.setString(1, hrid);
 					cacheReplaceStmt.setTimestamp(2, marcTimestamp);
 					cacheReplaceStmt.setString(3, marc);


### PR DESCRIPTION
The Folio Morning Glory release has normalized the timestamp format used in the SRS to match those used in other parts of Folio.