### PR TITLE
Don't retrieve LDP record lists as part of LDPChangeDetection

### DIFF
--- a/src/main/java/edu/cornell/library/integration/processing/LDPChangeDetection.java
+++ b/src/main/java/edu/cornell/library/integration/processing/LDPChangeDetection.java
@@ -15,7 +15,6 @@ import java.util.regex.Pattern;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import edu.cornell.library.integration.folio.LDPRecordLists;
 import edu.cornell.library.integration.folio.OkapiClient;
 import edu.cornell.library.integration.utilities.ComparisonLists;
 import edu.cornell.library.integration.utilities.Config;
@@ -25,10 +24,8 @@ public class LDPChangeDetection {
 	public static void main(String[] args) throws SQLException, IOException, InterruptedException {
 
 		List<String> requiredArgs = Config.getRequiredArgsForDB("Current");
-		requiredArgs.addAll(Config.getRequiredArgsForDB("LDP"));
 		Config config = Config.loadConfig(requiredArgs);
-		try (Connection ldp = config.getDatabaseConnection("LDP");
-			  Connection inventory = config.getDatabaseConnection("Current");
+		try (Connection inventory = config.getDatabaseConnection("Current");
 			  PreparedStatement queueDelete = inventory.prepareStatement
 				("INSERT INTO deleteQueue (hrid,priority,cause,record_date) VALUES (?,6,'LDP',NOW())");
 			  PreparedStatement queueAvail = inventory.prepareStatement
@@ -37,12 +34,6 @@ public class LDPChangeDetection {
 				("INSERT INTO generationQueue (hrid,priority,cause,record_date) VALUES (?,6,'LDP',?)")) {
 
 			OkapiClient folio = config.getOkapi("Folio");
-
-			LDPRecordLists.populateInstanceLDPList(inventory, ldp);
-			LDPRecordLists.populateBibLDPList(inventory, ldp);
-			LDPRecordLists.populateHoldingLDPList(inventory, ldp);
-			LDPRecordLists.populateItemLDPList(inventory, ldp);
-
 
 			{ // INSTANCES
 				ComparisonLists c = ResourceListComparison.compareLists(


### PR DESCRIPTION
The record lists can be retrieved during business hours by LDPRecordLists.java, allowing this analysis to be run at night while the LDP is unavailable. DISCOVERYACCESS-7804