### PR TITLE
The Hathi Database is fixed, so this temporary hotfix isn't needed

### DIFF
--- a/src/main/java/edu/cornell/library/integration/metadata/generator/HathiLinks.java
+++ b/src/main/java/edu/cornell/library/integration/metadata/generator/HathiLinks.java
@@ -41,7 +41,7 @@ public class HathiLinks implements SolrFieldGenerator {
 
 	@Override
 	// This field generator uses currently untracked HathiTrust content data, so should be regenerated more often.
-	public Duration resultsShelfLife() { return Duration.ofDays(730); } //TODO Revert to 14 days when Hathi DB fixed 
+	public Duration resultsShelfLife() { return Duration.ofDays(14); }
 
 	@Override
 	public SolrFields generateSolrFields( MarcRecord rec, Config config )


### PR DESCRIPTION
We set the shelf life of the Hathi data to two years in order to limit the regeneration of the data while the hathidb was broken.