### PR TITLE
Notes in browse indexes should always be json structured.

### DIFF
--- a/src/main/java/edu/cornell/library/integration/processing/Headings2Solr.java
+++ b/src/main/java/edu/cornell/library/integration/processing/Headings2Solr.java
@@ -136,7 +136,7 @@ public class Headings2Solr {
 					AuthorityStatus as = getIsAuthorized(id);
 					doc.addField("authority", ! as.equals(AuthorityStatus.NONE) );
 					doc.addField("mainEntry", as.equals(AuthorityStatus.MAIN) );
-					doc.addField("notes", getNotes(id));
+					doc.addField("notes", getNotes(this.connection, id));
 					String rda = getRda(id);
 					if (rda != null) doc.addField("rda_json", rda);
 					doc.addField("count",rs.getInt(hc.dbField()));
@@ -259,9 +259,9 @@ public class Headings2Solr {
 	}
 	
 	private static PreparedStatement note_pstmt = null;
-	private Collection<String> getNotes( int id ) throws SQLException {
+	public static Collection<String> getNotes( Connection headings, int id ) throws SQLException {
 		if (note_pstmt == null)
-			note_pstmt = this.connection.prepareStatement("SELECT note FROM note WHERE heading_id = ?");
+			note_pstmt = headings.prepareStatement("SELECT note FROM note WHERE heading_id = ?");
 		note_pstmt.setInt(1, id);
 		note_pstmt.execute();
 		Collection<String> notes = new ArrayList<>();

--- a/src/main/java/edu/cornell/library/integration/processing/Headings2Solr.java
+++ b/src/main/java/edu/cornell/library/integration/processing/Headings2Solr.java
@@ -266,8 +266,16 @@ public class Headings2Solr {
 		note_pstmt.execute();
 		Collection<String> notes = new ArrayList<>();
 		try ( ResultSet rs = note_pstmt.getResultSet() ){
-			while (rs.next())
-				notes.add( rs.getString("note") );
+			while (rs.next()) {
+				String note = rs.getString("note");
+				if (note.startsWith("[") && note.endsWith("]"))
+					notes.add( note );
+				else {
+					try {
+						notes.add(mapper.writeValueAsString(Arrays.asList(note)));
+					} catch (JsonProcessingException e) { e.printStackTrace(); }
+				}
+			}
 		}
 		return notes;
 	}

--- a/src/test/java/edu/cornell/library/integration/processing/Headings2SolrTest.java
+++ b/src/test/java/edu/cornell/library/integration/processing/Headings2SolrTest.java
@@ -1,0 +1,46 @@
+package edu.cornell.library.integration.processing;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Collection;
+import java.util.Iterator;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import edu.cornell.library.integration.db_test.DbBaseTest;
+
+public class Headings2SolrTest extends DbBaseTest {
+
+	@BeforeClass
+	public static void setup() throws IOException {
+		setup("Headings");
+	}
+
+	@Test
+	public void testGetNotes() throws SQLException {
+		try ( Connection conn = config.getDatabaseConnection("Headings") ){
+			// Corporate Name: Freemasons
+			Collection<String> notes = Headings2Solr.getNotes(conn, 296895);
+			assertEquals(1,notes.size());
+			assertEquals("[\"Search under: subdivision Freemasonry under names of persons\"]",notes.iterator().next());
+
+			// Topic: Mines and mineral resources
+			notes = Headings2Solr.getNotes(conn, 1537075);
+			Iterator<String> i = notes.iterator();
+			assertEquals(2,notes.size());
+			assertEquals("[\"Search under: headings beginning with the words Mine and Mining\"]",i.next());
+			assertEquals("[\"Search under: subdivision Effect of mining on under individual animals"
+					+ " and groups of animals, e.g. Fishes--Effect of mining on\"]",i.next());
+
+			// Person : Waugh, Hillary
+			notes = Headings2Solr.getNotes(conn, 4496);
+			assertEquals(1,notes.size());
+			assertEquals("[\"For works of this author entered under other names, search also under\","
+					+ "{\"header\":\"Grandower, Elissa\"},{\"header\":\"Taylor, H. Baldwin\"}]",notes.iterator().next());
+		}
+	}
+}

--- a/src/test/resources/example_db_data/db_initialization.sql
+++ b/src/test/resources/example_db_data/db_initialization.sql
@@ -67,6 +67,20 @@ CREATE TABLE `authority2reference` (
   KEY `authority_id` (`authority_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 
+CREATE TABLE `note` (
+  `heading_id` int(10) unsigned NOT NULL,
+  `authority_id` int(10) unsigned NOT NULL,
+  `note` text NOT NULL,
+  KEY `heading_id` (`heading_id`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+
+-- Heading2SolrTest data
+
+INSERT INTO note (heading_id, authority_id, note) VALUES (296895, 1440605, "Search under: subdivision Freemasonry under names of persons");
+INSERT INTO note (heading_id, authority_id, note) VALUES (1537075, 742440, "Search under: headings beginning with the words Mine and Mining");
+INSERT INTO note (heading_id, authority_id, note) VALUES (1537075, 742440, "Search under: subdivision Effect of mining on under individual animals and groups of animals, e.g. Fishes--Effect of mining on");
+INSERT INTO note (heading_id, authority_id, note) VALUES (4496, 2327, '["For works of this author entered under other names, search also under",{"header":"Grandower, Elissa"},{"header":"Taylor, H. Baldwin"}]');
+
 -- AuthorTitleTest data
 INSERT INTO authority (id, source, nativeId, nativeHeading, voyagerId, undifferentiated) VALUES (10422460, 0, "n 2017073745", "León Cupe, Mariano, 1932-", 10721247, 0);
 INSERT INTO heading (id, parent_id, heading, sort, heading_type, works_by, works_about, works) VALUES (18642914, 0, "León Cupe, Mariano, 1932-", "leon cupe mariano 1932", 0, 0, 0, 0);


### PR DESCRIPTION
One of the insert statements I added to the .sql file uses single quotes for quoting. Do you think that's safe? It cuts down on escaping for strings with a lot of internal double quotes.