### PR TITLE
Don't populate CJK values from non-880 into authority maintenance Sol…

### DIFF
--- a/src/main/java/edu/cornell/library/integration/metadata/generator/AuthorTitle.java
+++ b/src/main/java/edu/cornell/library/integration/metadata/generator/AuthorTitle.java
@@ -45,7 +45,7 @@ import edu.cornell.library.integration.utilities.SolrFields.SolrField;
 public class AuthorTitle implements SolrFieldGenerator {
 
 	@Override
-	public String getVersion() { return "1.3"; }
+	public String getVersion() { return "1.4"; }
 
 	@Override
 	public List<String> getHandledFields() {

--- a/src/main/java/edu/cornell/library/integration/metadata/generator/Subject.java
+++ b/src/main/java/edu/cornell/library/integration/metadata/generator/Subject.java
@@ -1,6 +1,6 @@
 package edu.cornell.library.integration.metadata.generator;
 
-import static edu.cornell.library.integration.utilities.CharacterSetUtils.hasCJK;
+import static edu.cornell.library.integration.utilities.CharacterSetUtils.isCJK;
 import static edu.cornell.library.integration.utilities.FilingNormalization.getFilingForm;
 import static edu.cornell.library.integration.utilities.IndexingUtilities.removeTrailingPunctuation;
 
@@ -45,7 +45,7 @@ public class Subject implements SolrFieldGenerator {
 	private static List<String> unwantedFacetValues = Arrays.asList("Electronic books");
 
 	@Override
-	public String getVersion() { return "2.4"; }
+	public String getVersion() { return "2.5"; }
 
 	@Override
 	public List<String> getHandledFields() {
@@ -241,7 +241,7 @@ public class Subject implements SolrFieldGenerator {
 					if (authData.alternateForms != null)
 						for (final String altForm : authData.alternateForms) {
 							authorityAltForms.add(altForm);
-							if (hasCJK(altForm))
+							if (isCJK(altForm))
 								authorityAltFormsCJK.add(altForm);
 						}
 					json.add(subj1);
@@ -262,7 +262,7 @@ public class Subject implements SolrFieldGenerator {
 						if (authData.authorized && authData.alternateForms != null)
 							for (final String altForm : authData.alternateForms) {
 								authorityAltForms.add(altForm);
-								if (hasCJK(altForm))
+								if (isCJK(altForm))
 									authorityAltFormsCJK.add(altForm);
 							}
 						json.add(subj);
@@ -319,13 +319,14 @@ public class Subject implements SolrFieldGenerator {
 					String filing = getFilingForm(value.display);
 					sfs.add(new SolrField("subject_"+ht.abbrev()+"_filing",filing));
 					String canonFiling = getFilingForm(value.canon);
-					if ( ! value.is880 ) {
+					if ( ! value.is880 && ! isCJK(value.canon)) {
 						String vocab = h.vocab.name().toLowerCase();
 						sfs.add(new SolrField("subject_"+ht.abbrev()+"_"+vocab+"_facet", value.canon));
 						sfs.add(new SolrField("subject_"+ht.abbrev()+"_"+vocab+"_filing",canonFiling));
 					}
 				}
 			for (final String s: values_dashed) {
+				if ( isCJK(s) ) continue;
 				String vocab = h.vocab.name().toLowerCase();
 				sfs.add(new SolrField("subject_sub_"+vocab+"_facet", removeTrailingPunctuation(s,".")));
 				sfs.add(new SolrField("subject_sub_"+vocab+"_filing",getFilingForm(s)));

--- a/src/main/java/edu/cornell/library/integration/metadata/generator/TitleChange.java
+++ b/src/main/java/edu/cornell/library/integration/metadata/generator/TitleChange.java
@@ -28,7 +28,7 @@ import edu.cornell.library.integration.utilities.SolrFields.SolrField;
 public class TitleChange implements SolrFieldGenerator {
 
 	@Override
-	public String getVersion() { return "1.4"; }
+	public String getVersion() { return "1.5"; }
 
 	@Override
 	public List<String> getHandledFields() {

--- a/src/main/java/edu/cornell/library/integration/utilities/NameUtils.java
+++ b/src/main/java/edu/cornell/library/integration/utilities/NameUtils.java
@@ -143,7 +143,8 @@ public class NameUtils {
 			sfs.add(new SolrField( filingField, getFilingForm( facet1 )));
 			String romanFiling = getFilingForm( facet2 );
 			sfs.add(new SolrField( filingField, romanFiling ));
-			sfs.add(new SolrField( romanFilingField, romanFiling ));
+			if ( ! isCJK(facet2) )
+				sfs.add(new SolrField( romanFilingField, romanFiling ));
 		}
 		if (fs.getFields().get(0).getScript().equals(Script.CJK))
 			sfs.add(new SolrField( (isMainAuthor)?"author_t_cjk":"author_addl_t_cjk", search1 ));
@@ -185,6 +186,8 @@ public class NameUtils {
 		if ( ! isMainAuthor && ctsVals.category.equals(HeadingCategory.AUTHORTITLE)) {
 			String browseDisplay = ctsVals.author+" | "+ctsVals.title;
 			String relation;
+
+			// ONE FIELD; INCLUDED WORK 7XX
 			if (f.ind2.equals('2')) {
 				relation = "included_work_display";
 				sfs.add(new SolrField("authortitle_facet",NameUtils.getFacetForm(browseDisplay)));
@@ -195,15 +198,15 @@ public class NameUtils {
 				String filingAuthorName = getFilingForm(authorFacet);
 				if ( f.mainTag.equals("700") ) {
 					sfs.add(new SolrField("author_pers_filing",filingAuthorName));
-					if ( ! f.tag.equals("880") )
+					if ( ! f.tag.equals("880") && ! isCJK( authorFacet ) )
 						sfs.add(new SolrField("author_pers_roman_filing",filingAuthorName));
 				} else if ( f.mainTag.equals("710") ) {
 					sfs.add(new SolrField("author_corp_filing",filingAuthorName));
-					if ( ! f.tag.equals("880") )
+					if ( ! f.tag.equals("880") && ! isCJK( authorFacet ) )
 						sfs.add(new SolrField("author_corp_roman_filing",filingAuthorName));
 				} else {
 					sfs.add(new SolrField("author_event_filing",filingAuthorName));
-					if ( ! f.tag.equals("880") )
+					if ( ! f.tag.equals("880") && ! isCJK( authorFacet ) )
 						sfs.add(new SolrField("author_event_roman_filing",filingAuthorName));
 				}
 			} else {
@@ -215,6 +218,7 @@ public class NameUtils {
 					+itemViewDisplay.title+"|"+ctsVals.title+"|"+ctsVals.author));
 			sfs.add(new SolrField((isCJK)?"title_uniform_t_cjk":"title_uniform_t",ctsVals.title));
 
+		// ONE FIELD; JUST AUTHOR
 		} else {
 			String display = NameUtils.displayValue( f, true );
 			if (display == null)
@@ -247,7 +251,7 @@ public class NameUtils {
 			if (filingField != null) {
 				String filing = getFilingForm( facet );
 				sfs.add(new SolrField( filingField, filing ));
-				if ( ! f.tag.equals("880") )
+				if ( ! f.tag.equals("880") && ! isCJK(facet) )
 					sfs.add(new SolrField( romanFilingField, filing ));
 			}
 

--- a/src/test/java/edu/cornell/library/integration/metadata/generator/AuthorTitleTest.java
+++ b/src/test/java/edu/cornell/library/integration/metadata/generator/AuthorTitleTest.java
@@ -539,4 +539,23 @@ public class AuthorTitleTest extends DbBaseTest {
 		"author_sort: guo li gu gong bo wu yuan\n";
 		assertEquals( expected, this.gen.generateSolrFields(rec, config).toString() );
 	}
+
+	@Test
+	public void cjk100() throws SQLException, IOException {
+		MarcRecord rec = new MarcRecord(MarcRecord.RecordType.BIBLIOGRAPHIC);
+		rec.id = "15331345";
+		rec.dataFields.add(new DataField(1,"100",'1',' ',"‡a 林玲子"));
+		String expected =
+		"author_display: 林玲子\n"+
+		"author_t: 林玲子\n"+
+		"author_facet: 林玲子\n"+
+		"author_pers_filing: 林玲子\n"+
+		"author_json: {\"name1\":\"林玲子\",\"search1\":\"林玲子\","
+		+ "\"relator\":\"\",\"type\":\"Personal Name\",\"authorizedForm\":false}\n"+
+		"author_sort: 林玲子\n";
+		assertEquals( expected, this.gen.generateSolrFields(rec, config).toString() );
+	}
+
+
 }
+

--- a/src/test/java/edu/cornell/library/integration/metadata/generator/SubjectTest.java
+++ b/src/test/java/edu/cornell/library/integration/metadata/generator/SubjectTest.java
@@ -449,4 +449,22 @@ public class SubjectTest extends DbBaseTest {
 		"fast_b: true\n";
 		assertEquals(expected,this.gen.generateSolrFields(rec, config).toString());
 	}
+
+	@Test // Should not populate vocabulary-specific fields intended for authority control
+	public void cjkIn6xx() throws SQLException, IOException {
+		MarcRecord rec = new MarcRecord(MarcRecord.RecordType.BIBLIOGRAPHIC);
+		rec.dataFields.add(new DataField(1,"650",' ','7',"‡a 子部 ‡x 小說家類. ‡2 sk"));
+		String expected =
+		"subject_t: 子部 > 小說家類\n"+
+		"subject_topic_facet: 子部\n"+
+		"subject_topic_filing: 子部\n"+
+		"subject_topic_facet: 子部 > 小說家類\n"+
+		"subject_topic_filing: 子部 0000 小說家類\n"+
+		"subject_json: [{\"subject\":\"子部\",\"authorized\":false,\"type\":\"Topical Term\"},"
+		+ "{\"subject\":\"小說家類.\",\"authorized\":false}]\n"+
+		"subject_display: 子部 > 小說家類\n"+
+		"fast_b: false\n";
+		assertEquals(expected,this.gen.generateSolrFields(rec, config).toString());
+
+	}
 }

--- a/src/test/java/edu/cornell/library/integration/metadata/generator/TitleChangeTest.java
+++ b/src/test/java/edu/cornell/library/integration/metadata/generator/TitleChangeTest.java
@@ -19,12 +19,6 @@ import edu.cornell.library.integration.utilities.SolrFields.SolrField;
 public class TitleChangeTest extends DbBaseTest {
 	SolrFieldGenerator gen = new TitleChange();
 
-//	@BeforeClass
-//	public static void setup() {
-//		List<String> requiredArgs = Config.getRequiredArgsForDB("Headings");
-//		config = Config.loadConfig(requiredArgs);
-//	}
-
 	@BeforeClass
 	public static void setup() throws IOException, SQLException {
 		setup("Headings");
@@ -394,4 +388,28 @@ public class TitleChangeTest extends DbBaseTest {
 				"‡a Vasilieva, Olga. ‡4 http://id.loc.gov/vocabulary/relators/edt"));
 	}
 
+	@Test
+	public void cjk700() throws SQLException, IOException {
+		MarcRecord rec = new MarcRecord(MarcRecord.RecordType.BIBLIOGRAPHIC);
+		rec.dataFields.add(new DataField(1,"700",'1',' ',"‡a 林玲子"));
+		String expected =
+		"author_addl_display: 林玲子\n"+
+		"author_addl_t: 林玲子\n"+
+		"author_facet: 林玲子\n"+
+		"author_pers_filing: 林玲子\n"+
+		"author_addl_json: {\"name1\":\"林玲子\",\"search1\":\"林玲子\","
+		+ "\"relator\":\"\",\"type\":\"Personal Name\",\"authorizedForm\":false}\n";
+		assertEquals(expected,this.gen.generateSolrFields(rec, config).toString());
+		rec = new MarcRecord(MarcRecord.RecordType.BIBLIOGRAPHIC);
+		rec.dataFields.add(new DataField(1,"700",'1','2',"‡a 林玲子 ‡t Some title"));
+		expected =
+		"authortitle_facet: 林玲子 | Some title\n"+
+		"authortitle_filing: 林玲子 0000 some title\n"+
+		"author_addl_t: 林玲子\n"+
+		"author_facet: 林玲子\n"+
+		"author_pers_filing: 林玲子\n"+
+		"included_work_display: 林玲子 Some title|Some title|林玲子\n"+
+		"title_uniform_t: Some title\n";
+		assertEquals(expected,this.gen.generateSolrFields(rec, config).toString());
+	}
 }


### PR DESCRIPTION
All we want to do here is take CJK values in non 880 fields out of the non-public-facing Solr fields used for authorities maintenance.

DISCOVERYACCESS-7439