### PR TITLE
Use non-880 subject field's 2nd indicator to determine source vocab

### DIFF
--- a/src/main/java/edu/cornell/library/integration/metadata/generator/Subject.java
+++ b/src/main/java/edu/cornell/library/integration/metadata/generator/Subject.java
@@ -45,7 +45,7 @@ public class Subject implements SolrFieldGenerator {
 	private static List<String> unwantedFacetValues = Arrays.asList("Electronic books");
 
 	@Override
-	public String getVersion() { return "2.5"; }
+	public String getVersion() { return "2.6"; }
 
 	@Override
 	public List<String> getHandledFields() {
@@ -78,7 +78,8 @@ public class Subject implements SolrFieldGenerator {
 
 			// First DataField in each FieldSet should be representative, so we'll examine that.
 			final Heading h = new Heading();
-			final DataField f = fs.getFields().get(0);
+			final DataField f = fs.getFields().get(fs.getFields().size()-1);
+//			final DataField f = fs.getFields().get(0);
 			switch (f.ind2) {
 			case '0':
 				h.vocab = HeadingVocab.LC;

--- a/src/main/java/edu/cornell/library/integration/metadata/generator/Subject.java
+++ b/src/main/java/edu/cornell/library/integration/metadata/generator/Subject.java
@@ -76,7 +76,7 @@ public class Subject implements SolrFieldGenerator {
 		SolrFields sfs = new SolrFields();
 		for( DataFieldSet fs: sets ) {
 
-			// First DataField in each FieldSet should be representative, so we'll examine that.
+			// For the purposes of id'ing vocabulary, the Roman (last) field is most reliable, so we'll examine that.
 			final Heading h = new Heading();
 			final DataField f = fs.getFields().get(fs.getFields().size()-1);
 			switch (f.ind2) {

--- a/src/main/java/edu/cornell/library/integration/metadata/generator/Subject.java
+++ b/src/main/java/edu/cornell/library/integration/metadata/generator/Subject.java
@@ -79,7 +79,6 @@ public class Subject implements SolrFieldGenerator {
 			// First DataField in each FieldSet should be representative, so we'll examine that.
 			final Heading h = new Heading();
 			final DataField f = fs.getFields().get(fs.getFields().size()-1);
-//			final DataField f = fs.getFields().get(0);
 			switch (f.ind2) {
 			case '0':
 				h.vocab = HeadingVocab.LC;

--- a/src/test/java/edu/cornell/library/integration/metadata/generator/SubjectTest.java
+++ b/src/test/java/edu/cornell/library/integration/metadata/generator/SubjectTest.java
@@ -465,6 +465,43 @@ public class SubjectTest extends DbBaseTest {
 		"subject_display: 子部 > 小說家類\n"+
 		"fast_b: false\n";
 		assertEquals(expected,this.gen.generateSolrFields(rec, config).toString());
-
 	}
+
+	@Test
+	public void matching880withwrong2ndIndicator() throws SQLException, IOException {
+		MarcRecord rec = new MarcRecord(MarcRecord.RecordType.BIBLIOGRAPHIC);
+		rec.id = "5071114";
+		rec.dataFields.add(new DataField(1,4,"600",'1','0',"‡6 880-06 ‡a Zhang, Lei, ‡d 1054-1114 ‡v Chronology.",false));
+		rec.dataFields.add(new DataField(2,4,"600",'1','4',"‡6 600-06/$1 ‡a 張耒, ‡d 1054-1114 ‡v Chronology.",true));
+		/* This name actually does have an authority record, but we have other tests to capture that, so
+		 * I saw no need to import that into the test suite just to get 9 alternate forms of the name adding
+		 * to the expected Solr results.
+		 */
+		String expected =
+		"subject_t: 張耒, 1054-1114 > Chronology\n"+
+		"subject_t: Zhang, Lei, 1054-1114 > Chronology\n"+
+		"subject_pers_facet: 張耒, 1054-1114\n"+
+		"subject_pers_filing: 張耒 1054 1114\n"+
+		"subject_pers_facet: 張耒, 1054-1114 > Chronology\n"+
+		"subject_pers_filing: 張耒 1054 1114 0000 chronology\n"+
+		"subject_pers_facet: Zhang, Lei, 1054-1114\n"+
+		"subject_pers_filing: zhang lei 1054 1114\n"+
+		"subject_pers_lc_facet: Zhang, Lei, 1054-1114\n"+
+		"subject_pers_lc_filing: zhang lei 1054 1114\n"+
+		"subject_pers_facet: Zhang, Lei, 1054-1114 > Chronology\n"+
+		"subject_pers_filing: zhang lei 1054 1114 0000 chronology\n"+
+		"subject_pers_lc_facet: Zhang, Lei, 1054-1114 > Chronology\n"+
+		"subject_pers_lc_filing: zhang lei 1054 1114 0000 chronology\n"+
+		"subject_sub_lc_facet: Chronology\n"+
+		"subject_sub_lc_filing: chronology\n"+
+		"subject_json: [{\"subject\":\"張耒, 1054-1114\",\"authorized\":false,\"type\":\"Personal Name\"},"
+		+ "{\"subject\":\"Chronology.\",\"authorized\":false}]\n"+
+		"subject_json: [{\"subject\":\"Zhang, Lei, 1054-1114\",\"authorized\":false,\"type\":\"Personal Name\"},"
+		+ "{\"subject\":\"Chronology.\",\"authorized\":false}]\n"+
+		"subject_display: 張耒, 1054-1114 > Chronology\n"+
+		"subject_display: Zhang, Lei, 1054-1114 > Chronology\n"+
+		"fast_b: false\n";
+		assertEquals(expected,this.gen.generateSolrFields(rec, config).toString());
+	}
+
 }


### PR DESCRIPTION
When an 880 field and a non-880 field are linked as non-Roman and Romanized equivalents, we generally give the 880 (non-Roman) value precedence, as that is the original value even when the derivative non-880 (Romanized) is recognized by name authority.

When the non-880 (Romanized) value is authorized, both fields should have a 2nd indicator reflecting that, but it's a common error to flag the 880 (non-Roman) value as unauthorized because the non-Roman value IN THAT FIELD, is not specifically authorized.

So, given the higher reliability of the 2nd indicator in the Romanized field, we can simply give precedence to that indicator, making this a very simple fix.

DISCOVERYACCESS-8135