### PR TITLE
Move former owner added entry fields from author search to provenance

### DIFF
--- a/src/main/java/edu/cornell/library/integration/metadata/generator/TitleChange.java
+++ b/src/main/java/edu/cornell/library/integration/metadata/generator/TitleChange.java
@@ -28,7 +28,7 @@ import edu.cornell.library.integration.utilities.SolrFields.SolrField;
 public class TitleChange implements SolrFieldGenerator {
 
 	@Override
-	public String getVersion() { return "1.5"; }
+	public String getVersion() { return "1.6"; }
 
 	@Override
 	public List<String> getHandledFields() {

--- a/src/main/java/edu/cornell/library/integration/metadata/support/Relator.java
+++ b/src/main/java/edu/cornell/library/integration/metadata/support/Relator.java
@@ -15,7 +15,7 @@ package edu.cornell.library.integration.metadata.support;
  * r.name();     // returns "aut". <br/>
  * <br/>
  * Relator r = Relator.valueOf("invalid code"); <br/>
- *   // -> throws IllegalArgumentException
+ *   // -> throws IllegalArgumentException <br/>
  * Relator r = Relator.valueOfString("invalid term"); <br/>
  *   // -> returns null
  * 

--- a/src/main/java/edu/cornell/library/integration/metadata/support/RelatorSet.java
+++ b/src/main/java/edu/cornell/library/integration/metadata/support/RelatorSet.java
@@ -13,6 +13,7 @@ import edu.cornell.library.integration.marc.Subfield;
 public class RelatorSet {
 
 	Set<String> relators = new LinkedHashSet<>();
+	final ProvStatus isProvenance;
 
 	private final String RelatorCodeURIPrefix = "http://id.loc.gov/vocabulary/relators/";
 	public RelatorSet(DataField f) {
@@ -45,6 +46,12 @@ public class RelatorSet {
 				}
 			}
 		}
+
+		// Name is considered provenance if it is a former owner. If it has other relators, it may also be a creator.
+		if ( this.relators.isEmpty() || ! this.relators.contains("former owner") ) {
+			this.isProvenance = ProvStatus.NONE; return;
+		}
+		this.isProvenance = ( this.relators.size() == 1 ) ? ProvStatus.PROV_ONLY : ProvStatus.PROV_CREATOR;
 	}
 	public boolean isEmpty() {
 		return this.relators.isEmpty();
@@ -72,7 +79,14 @@ public class RelatorSet {
 			return s;
 		return s+",";
 	}
+
+	public ProvStatus isProvenance() { return this.isProvenance; }
+
 	private static Pattern neededTerminalPeriod
 		= Pattern.compile("(.*)(etc|Mrs|Inc|Sr|Jr|Spon|Co|Inc|Ltd|[A-Z])\\.([\\-,]?)$");
+
+	public enum ProvStatus {
+		PROV_ONLY, PROV_CREATOR, NONE;
+	}
 
 }

--- a/src/main/java/edu/cornell/library/integration/metadata/support/RelatorSet.java
+++ b/src/main/java/edu/cornell/library/integration/metadata/support/RelatorSet.java
@@ -56,6 +56,9 @@ public class RelatorSet {
 	public boolean isEmpty() {
 		return this.relators.isEmpty();
 	}
+	public void remove(String relator) {
+		relators.remove(relator);
+	}
 	@Override
 	public String toString() {
 		return String.join(", ",this.relators);

--- a/src/main/java/edu/cornell/library/integration/utilities/NameUtils.java
+++ b/src/main/java/edu/cornell/library/integration/utilities/NameUtils.java
@@ -144,11 +144,13 @@ public class NameUtils {
 
 		boolean includeInAuthor = ! rs.isProvenance().equals(ProvStatus.PROV_ONLY);
 		boolean includeInProvenance = ! rs.isProvenance().equals(ProvStatus.NONE);
+		boolean displayAsFMO = rs.isProvenance().equals(ProvStatus.PROV_ONLY);
 
 		if (includeInProvenance) {
 			rs.remove("former owner");
 			String d = NameUtils.displayValue( fs.getFields().get(1), rs, true );
-			sfs.add(new SolrField( "former_owner_display" , display1 +" / "+d));
+			if (displayAsFMO)
+				sfs.add(new SolrField( "former_owner_display" , display1 +" / "+d));
 			sfs.add(new SolrField( "former_owner_t", display1 ));
 			sfs.add(new SolrField( "former_owner_t", d ));
 		}
@@ -270,11 +272,14 @@ public class NameUtils {
 
 			boolean includeInAuthor = ! rs.isProvenance().equals(ProvStatus.PROV_ONLY);
 			boolean includeInProvenance = ! rs.isProvenance().equals(ProvStatus.NONE);
+			boolean displayAsFMO = rs.isProvenance().equals(ProvStatus.PROV_ONLY);
+
 
 			if (includeInProvenance) {
 				rs.remove("former owner");
 				String d = NameUtils.displayValue( f, rs, true );
-				sfs.add(new SolrField( "former_owner_display" , d));
+				if (displayAsFMO)
+					sfs.add(new SolrField( "former_owner_display" , d));
 				sfs.add(new SolrField( "former_owner_t", d));
 			}
 

--- a/src/main/java/edu/cornell/library/integration/utilities/NameUtils.java
+++ b/src/main/java/edu/cornell/library/integration/utilities/NameUtils.java
@@ -22,6 +22,7 @@ import edu.cornell.library.integration.metadata.support.AuthorityData;
 import edu.cornell.library.integration.metadata.support.HeadingCategory;
 import edu.cornell.library.integration.metadata.support.HeadingType;
 import edu.cornell.library.integration.metadata.support.RelatorSet;
+import edu.cornell.library.integration.metadata.support.RelatorSet.ProvStatus;
 import edu.cornell.library.integration.utilities.SolrFields.SolrField;
 
 public class NameUtils {
@@ -43,7 +44,7 @@ public class NameUtils {
 		return f.concatenateSpecificSubfields(facetSubfields);
 	}
 
-	public static String displayValue(DataField f, Boolean includeSuffixes) {
+	public static String displayValue(DataField f, RelatorSet rs, Boolean includeSuffixes) {
 
 		String displaySubfields;
 		if ( f.mainTag.endsWith("00") || f.mainTag.endsWith("20") )
@@ -61,7 +62,6 @@ public class NameUtils {
 		String suffixes = (f.mainTag.endsWith("00")) ? f.concatenateSpecificSubfields("d") : "";
 		if ( ! suffixes.isEmpty() )
 			suffixes = " "+suffixes;
-		final RelatorSet rs = new RelatorSet(f);
 		if ( ! rs.isEmpty() ) {
 			if (suffixes.isEmpty())
 				mainValue = RelatorSet.validateForConcatWRelators(mainValue);
@@ -110,9 +110,11 @@ public class NameUtils {
 			Config config, DataFieldSet fs, List<FieldValues> ctsValsList, Boolean isMainAuthor )
 					throws SQLException, IOException {
 
-		String display1 = NameUtils.displayValue( fs.getFields().get(0), false );
-		String display2 = NameUtils.displayValue( fs.getFields().get(1), true );
-		String search1 = NameUtils.displayValue( fs.getFields().get(0), true );
+		RelatorSet rs = new RelatorSet(fs.getFields().get(1));
+
+		String display1 = NameUtils.displayValue( fs.getFields().get(0), null, false );
+		String display2 = NameUtils.displayValue( fs.getFields().get(1), rs,   true );
+		String search1 = NameUtils.displayValue(  fs.getFields().get(0), rs,   true );
 		String facet1 = NameUtils.facetValue( fs.getFields().get(0) );
 		String facet2 = NameUtils.facetValue( fs.getFields().get(1) );
 		HeadingType ht;
@@ -135,16 +137,29 @@ public class NameUtils {
 		}
 
 		List<SolrField> sfs = new ArrayList<>();
-		sfs.add(new SolrField( (isMainAuthor)?"author_display":"author_addl_display",
-				display1 +" / "+display2 ));
+		// romanFilingField is a staff-facing search endpoint for authority control maintenance.
+		String romanFiling = getFilingForm( facet2 );
+		if ( romanFilingField != null && ! isCJK(facet2) )
+			sfs.add(new SolrField( romanFilingField, romanFiling ));
+
+		boolean includeInAuthor = ! rs.isProvenance().equals(ProvStatus.PROV_ONLY);
+		boolean includeInProvenance = ! rs.isProvenance().equals(ProvStatus.NONE);
+
+		if (includeInProvenance) {
+			sfs.add(new SolrField( "former_owner_display" , display1 +" / "+display2));
+			sfs.add(new SolrField( "former_owner_t", display1 ));
+			sfs.add(new SolrField( "former_owner_t", display2 ));
+		}
+
+
+		if ( ! includeInAuthor) return sfs;
+
+		sfs.add(new SolrField( (isMainAuthor)? "author_display":"author_addl_display", display1 +" / "+display2));
 		sfs.add(new SolrField( "author_facet", NameUtils.getFacetForm( facet1 )));
 		sfs.add(new SolrField( "author_facet", NameUtils.getFacetForm( facet2 )));
 		if (filingField != null) {
 			sfs.add(new SolrField( filingField, getFilingForm( facet1 )));
-			String romanFiling = getFilingForm( facet2 );
 			sfs.add(new SolrField( filingField, romanFiling ));
-			if ( ! isCJK(facet2) )
-				sfs.add(new SolrField( romanFilingField, romanFiling ));
 		}
 		if (fs.getFields().get(0).getScript().equals(Script.CJK))
 			sfs.add(new SolrField( (isMainAuthor)?"author_t_cjk":"author_addl_t_cjk", search1 ));
@@ -220,10 +235,14 @@ public class NameUtils {
 
 		// ONE FIELD; JUST AUTHOR
 		} else {
-			String display = NameUtils.displayValue( f, true );
+			RelatorSet rs = new RelatorSet(f);
+
+			String display = NameUtils.displayValue( f, rs, true );
 			if (display == null)
 				return sfs;
 			String facet = NameUtils.facetValue( f );
+			String filing = getFilingForm( facet );
+
 			HeadingType ht;
 			String filingField;
 			String romanFilingField;
@@ -243,17 +262,27 @@ public class NameUtils {
 				ht = null; filingField = null; romanFilingField = null;
 			}
 
+			// romanFilingField is a staff-facing search endpoint for authority control maintenance.
+			if ( romanFilingField != null && ! f.tag.equals("880") && ! isCJK(facet) )
+				sfs.add(new SolrField( romanFilingField, filing ));
+
+			boolean includeInAuthor = ! rs.isProvenance().equals(ProvStatus.PROV_ONLY);
+			boolean includeInProvenance = ! rs.isProvenance().equals(ProvStatus.NONE);
+
+			if (includeInProvenance) {
+				sfs.add(new SolrField( "former_owner_display" , display));
+				sfs.add(new SolrField( "former_owner_t", display));
+			}
+
+			if ( ! includeInAuthor) return sfs;
+
 			sfs.add(new SolrField( (isMainAuthor)?"author_display":"author_addl_display", display ));
 			sfs.add(new SolrField( (isCJK)?
 					(isMainAuthor)?"author_t_cjk":"author_addl_t_cjk":
 						(isMainAuthor)?"author_t":"author_addl_t", display ));
 			sfs.add(new SolrField( "author_facet", NameUtils.getFacetForm( facet )));
-			if (filingField != null) {
-				String filing = getFilingForm( facet );
+			if (filingField != null)
 				sfs.add(new SolrField( filingField, filing ));
-				if ( ! f.tag.equals("880") && ! isCJK(facet) )
-					sfs.add(new SolrField( romanFilingField, filing ));
-			}
 
 			final Map<String,Object> json = new LinkedHashMap<>();
 			json.put("name1", display);

--- a/src/main/java/edu/cornell/library/integration/utilities/NameUtils.java
+++ b/src/main/java/edu/cornell/library/integration/utilities/NameUtils.java
@@ -146,9 +146,11 @@ public class NameUtils {
 		boolean includeInProvenance = ! rs.isProvenance().equals(ProvStatus.NONE);
 
 		if (includeInProvenance) {
-			sfs.add(new SolrField( "former_owner_display" , display1 +" / "+display2));
+			rs.remove("former owner");
+			String d = NameUtils.displayValue( fs.getFields().get(1), rs, true );
+			sfs.add(new SolrField( "former_owner_display" , display1 +" / "+d));
 			sfs.add(new SolrField( "former_owner_t", display1 ));
-			sfs.add(new SolrField( "former_owner_t", display2 ));
+			sfs.add(new SolrField( "former_owner_t", d ));
 		}
 
 
@@ -270,8 +272,10 @@ public class NameUtils {
 			boolean includeInProvenance = ! rs.isProvenance().equals(ProvStatus.NONE);
 
 			if (includeInProvenance) {
-				sfs.add(new SolrField( "former_owner_display" , display));
-				sfs.add(new SolrField( "former_owner_t", display));
+				rs.remove("former owner");
+				String d = NameUtils.displayValue( f, rs, true );
+				sfs.add(new SolrField( "former_owner_display" , d));
+				sfs.add(new SolrField( "former_owner_t", d));
 			}
 
 			if ( ! includeInAuthor) return sfs;

--- a/src/test/java/edu/cornell/library/integration/metadata/generator/AuthorTitleTest.java
+++ b/src/test/java/edu/cornell/library/integration/metadata/generator/AuthorTitleTest.java
@@ -52,11 +52,11 @@ public class AuthorTitleTest extends DbBaseTest {
 		rec.dataFields.add(new DataField(2,"245",'1','0',"‡a Cabana, historia, cultura y tradición / ‡c Mariano"
 				+ " León Cupe, Jorge León Quispe."));
 		String expected =
+		"author_pers_roman_filing: leon cupe mariano 1932\n"+
 		"author_display: León Cupe, Mariano, 1932-\n"+
 		"author_t: León Cupe, Mariano, 1932-\n"+
 		"author_facet: León Cupe, Mariano, 1932-\n"+
 		"author_pers_filing: leon cupe mariano 1932\n"+
-		"author_pers_roman_filing: leon cupe mariano 1932\n"+
 		"author_json: {\"name1\":\"León Cupe, Mariano, 1932-\",\"search1\":\"León Cupe, Mariano, 1932-\","+
 									"\"relator\":\"\",\"type\":\"Personal Name\",\"authorizedForm\":true}\n"+
 		"authority_author_t: Cupe, Mariano León, 1932-\n"+
@@ -84,11 +84,11 @@ public class AuthorTitleTest extends DbBaseTest {
 		rec.dataFields.add(new DataField(2,"245",'1','0',"‡a Waterford people : ‡b a biographical dictionary / "
 				+ "‡c T. N. Fewer."));
 		String expected =
+		"author_pers_roman_filing: fewer t n\n"+
 		"author_display: Fewer, T. N.\n"+
 		"author_t: Fewer, T. N.\n"+
 		"author_facet: Fewer, T. N.\n"+
 		"author_pers_filing: fewer t n\n"+
-		"author_pers_roman_filing: fewer t n\n"+
 		"author_json: {\"name1\":\"Fewer, T. N.\",\"search1\":\"Fewer, T. N.\",\"relator\":\"\",\"type\":"+
 										"\"Personal Name\",\"authorizedForm\":true}\n"+
 		"authority_author_t: Fewer, Tom\n"+
@@ -118,11 +118,11 @@ public class AuthorTitleTest extends DbBaseTest {
 		rec.dataFields.add(new DataField(2,"245",'1','0',"‡a Lumps and bumps in the mouth and lips"
 				+ " ‡h [electronic resource] / ‡c Nicholas Kalavrezos."));
 		String expected =
+		"author_pers_roman_filing: kalavrezos nicholas\n"+
 		"author_display: Kalavrezos, Nicholas, speaker\n"+
 		"author_t: Kalavrezos, Nicholas, speaker\n"+
 		"author_facet: Kalavrezos, Nicholas\n"+
 		"author_pers_filing: kalavrezos nicholas\n"+
-		"author_pers_roman_filing: kalavrezos nicholas\n"+
 		"author_json: {\"name1\":\"Kalavrezos, Nicholas, speaker\",\"search1\":\"Kalavrezos, Nicholas,\","
 		+ "\"relator\":\"speaker\",\"type\":\"Personal Name\",\"authorizedForm\":false}\n"+
 		"author_sort: kalavrezos nicholas\n"+
@@ -150,11 +150,11 @@ public class AuthorTitleTest extends DbBaseTest {
 		rec.dataFields.add(new DataField(3,"245",'1','0',"‡a Britain's Tudor maps : ‡b county by county /"
 				+ " ‡c John Speed ; introduction by Nigel Nicolson ; country commentaries by Alasdair Hawkyard."));
 		String expected =
+		"author_pers_roman_filing: speed john 1552 1629\n"+
 		"author_display: Speed, John, 1552?-1629, cartographer\n"+
 		"author_t: Speed, John, 1552?-1629, cartographer\n"+
 		"author_facet: Speed, John, 1552?-1629\n"+
 		"author_pers_filing: speed john 1552 1629\n"+
-		"author_pers_roman_filing: speed john 1552 1629\n"+
 		"author_json: {\"name1\":\"Speed, John, 1552?-1629, cartographer\",\"search1\":\"Speed, John, 1552?-1629,\","
 		+ "\"relator\":\"cartographer\",\"type\":\"Personal Name\",\"authorizedForm\":true}\n"+
 		"authority_author_t: I. S., 1552?-1629\n"+
@@ -197,11 +197,11 @@ public class AuthorTitleTest extends DbBaseTest {
 		rec.dataFields.add(new DataField(2,"245",'1','4',"‡a Hē ennoia tou oikou ston Euripidē : ‡b Alkēstē, Mēdeia,"
 				+ " Hippolytos / ‡c Loukas Papadēmētropoulos."));
 		String expected =
+		"author_pers_roman_filing: papademetropoulos loukas p\n"+
 		"author_display: Papadēmētropoulos, Loukas P., author\n"+
 		"author_t: Papadēmētropoulos, Loukas P., author\n"+
 		"author_facet: Papadēmētropoulos, Loukas P.\n"+
 		"author_pers_filing: papademetropoulos loukas p\n"+
-		"author_pers_roman_filing: papademetropoulos loukas p\n"+
 		"author_json: {\"name1\":\"Papadēmētropoulos, Loukas P., author\",\"search1\":\"Papadēmētropoulos, Loukas P.,\""
 		+ ",\"relator\":\"author\",\"type\":\"Personal Name\",\"authorizedForm\":true}\n"+
 		"author_sort: papademetropoulos loukas p\n"+
@@ -271,12 +271,12 @@ public class AuthorTitleTest extends DbBaseTest {
 		rec.dataFields.add(new DataField(6,3,"245",'1','0',"‡6 245-03/$1 ‡a 남자 문제 의 시대 = ‡b 男子問題の時代?"
 				+ " : 젠더 와 교육 의 정치학 / ‡c 다가 후토시 지음 ; 책사소 옮김.",true));
 		String expected =
+		"author_pers_roman_filing: taga futoshi 1968\n"+
 		"author_display: 多賀太 / Taga, Futoshi, 1968- author\n"+
 		"author_facet: 多賀太, 1968-\n"+
 		"author_facet: Taga, Futoshi, 1968-\n"+
 		"author_pers_filing: 多賀太 1968\n"+
 		"author_pers_filing: taga futoshi 1968\n"+
-		"author_pers_roman_filing: taga futoshi 1968\n"+
 		"author_t_cjk: 多賀太, 1968- author\n"+
 		"author_t: Taga, Futoshi, 1968- author\n"+
 		"author_json: {\"name1\":\"多賀太\",\"search1\":\"多賀太, 1968-\",\"name2\":\"Taga, Futoshi, 1968- author\","
@@ -323,11 +323,11 @@ public class AuthorTitleTest extends DbBaseTest {
 		rec.dataFields.add(new DataField(3,"245",'1','0',"‡a Tjita dan daja pemuda Islam :"
 				+ " ‡b menjongsong Mu'tamar & P.O.R. G.P.I.I. ke IX 25 s/d 31 Oktober 1959 di Djakarta."));
 		String expected =
+		"author_corp_roman_filing: gerakan pemuda islam indonesia mutamar\n"+
 		"author_display: Gerakan Pemuda Islam Indonesia. Mu'tamar (9th : 1959 : Jakarta, Indonesia)\n"+
 		"author_t: Gerakan Pemuda Islam Indonesia. Mu'tamar (9th : 1959 : Jakarta, Indonesia)\n"+
 		"author_facet: Gerakan Pemuda Islam Indonesia. Mu'tamar\n"+
 		"author_corp_filing: gerakan pemuda islam indonesia mutamar\n"+
-		"author_corp_roman_filing: gerakan pemuda islam indonesia mutamar\n"+
 		"author_json: {\"name1\":\"Gerakan Pemuda Islam Indonesia. Mu'tamar (9th : 1959 : Jakarta, Indonesia)\","
 		+ "\"search1\":\"Gerakan Pemuda Islam Indonesia. Mu'tamar (9th : 1959 : Jakarta, Indonesia)\","
 		+ "\"relator\":\"\",\"type\":\"Corporate Name\",\"authorizedForm\":false}\n"+
@@ -369,11 +369,11 @@ public class AuthorTitleTest extends DbBaseTest {
 				"‡6 245-01/$1 ‡a 佛教艺术的早期阶段 = ‡b The beginnings of Buddhist art and other essays in Indian and"
 				+ " Central-Asian archaeology / ‡c c阿・福歇 (A. Foucher) 著 ; 王平先, 魏文捷译 ; 王冀青审校.",true));
 		String expected =
+		"author_pers_roman_filing: foucher a alfred 1865 1952\n"+
 		"author_display: Foucher, A. (Alfred), 1865-1952.\n"+
 		"author_t: Foucher, A. (Alfred), 1865-1952.\n"+
 		"author_facet: Foucher, A. (Alfred), 1865-1952\n"+
 		"author_pers_filing: foucher a alfred 1865 1952\n"+
-		"author_pers_roman_filing: foucher a alfred 1865 1952\n"+
 		"author_json: {\"name1\":\"Foucher, A. (Alfred), 1865-1952.\",\"search1\":\"Foucher, A. (Alfred), "
 		+ "1865-1952.\",\"relator\":\"\",\"type\":\"Personal Name\",\"authorizedForm\":true}\n"+
 		"authority_author_t: Foucher, Alfred Charles Auguste, 1865-1952\n"+
@@ -429,12 +429,12 @@ public class AuthorTitleTest extends DbBaseTest {
 		rec.dataFields.add(new DataField(4,2,"245",'0','0',
 				"‡6 245-02 ‡a Черноморский флот в период правления Екатерины II",true));
 		String expected =
+		"author_pers_roman_filing: grebenshchikova g a\n"+
 		"author_display: Гребенщикова, Г. А. / Grebenshchikova, G. A., author\n"+
 		"author_facet: Гребенщикова, Г. А.\n"+
 		"author_facet: Grebenshchikova, G. A.\n"+
 		"author_pers_filing: гребенщикова г а\n"+
 		"author_pers_filing: grebenshchikova g a\n"+
-		"author_pers_roman_filing: grebenshchikova g a\n"+
 		"author_t: Гребенщикова, Г. А, author\n"+
 		"author_t: Grebenshchikova, G. A., author\n"+
 		"author_json: {\"name1\":\"Гребенщикова, Г. А.\",\"search1\":\"Гребенщикова, Г. А,\","
@@ -470,10 +470,10 @@ public class AuthorTitleTest extends DbBaseTest {
 		rec.dataFields.add(new DataField(1,0,"110",'1',' ',"‡a Korea (South). ‡b President (1993-1998 : Kim)",false));
 		rec.dataFields.add(new DataField(2,0,"100",'1',' ',"‡6 100-00/$1 ‡a 金泳三, ‡d 1927-",true));
 		String expected =
+		"author_corp_roman_filing: korea south president 1993 1998 kim\n"+
 		"author_t: Korea (South). President (1993-1998 : Kim)\n"+
 		"author_facet: Korea (South). President (1993-1998 : Kim)\n"+
 		"author_corp_filing: korea south president 1993 1998 kim\n"+
-		"author_corp_roman_filing: korea south president 1993 1998 kim\n"+
 		"author_json: {\"name1\":\"Korea (South). President (1993-1998 : Kim)\",\"search1\":\"Korea (South)."
 		+ " President (1993-1998 : Kim)\",\"relator\":\"\",\"type\":\"Corporate Name\",\"authorizedForm\":true}\n"+
 		"author_t_cjk: 金泳三, 1927-\n"+
@@ -496,11 +496,11 @@ public class AuthorTitleTest extends DbBaseTest {
 		rec.dataFields.add(new DataField(2,0,"100",'1','0',"‡6 100-00/$1 ‡a 蔡玫芬.",true));
 		rec.dataFields.add(new DataField(3,1,"110",'2','0',"‡6 110-01/$1 ‡a 國立故宮博物院.",true));
 		String expected =
+		"author_corp_roman_filing: guo li gu gong bo wu yuan\n"+
 		"author_facet: 國立故宮博物院\n"+
 		"author_facet: Guo li gu gong bo wu yuan\n"+
 		"author_corp_filing: 國立故宮博物院\n"+
 		"author_corp_filing: guo li gu gong bo wu yuan\n"+
-		"author_corp_roman_filing: guo li gu gong bo wu yuan\n"+
 		"author_t_cjk: 國立故宮博物院.\n"+
 		"author_t: Guo li gu gong bo wu yuan.\n"+
 		"author_json: {\"name1\":\"國立故宮博物院\",\"search1\":\"國立故宮博物院.\",\"name2\":"

--- a/src/test/java/edu/cornell/library/integration/metadata/generator/TitleChangeTest.java
+++ b/src/test/java/edu/cornell/library/integration/metadata/generator/TitleChangeTest.java
@@ -423,8 +423,8 @@ public class TitleChangeTest extends DbBaseTest {
 		rec.dataFields.add(new DataField(1,"700",'1',' ',"‡a Ammons, A. R., ‡d 1926-2001 ‡e former owner. ‡5 NIC"));
 		String expected =
 		"author_pers_roman_filing: ammons a r 1926 2001\n"+
-		"former_owner_display: Ammons, A. R., 1926-2001, former owner\n"+
-		"former_owner_t: Ammons, A. R., 1926-2001, former owner\n";
+		"former_owner_display: Ammons, A. R., 1926-2001\n"+
+		"former_owner_t: Ammons, A. R., 1926-2001\n";
 		assertEquals(expected,this.gen.generateSolrFields(rec, config).toString());
 	}
 
@@ -434,8 +434,8 @@ public class TitleChangeTest extends DbBaseTest {
 		rec.dataFields.add(new DataField(1,"710",'1',' ',"‡a Some corporate entity ‡e former owner, ‡e author."));
 		String expected =
 		"author_corp_roman_filing: some corporate entity\n"+
-		"former_owner_display: Some corporate entity, former owner, author\n"+
-		"former_owner_t: Some corporate entity, former owner, author\n"+
+		"former_owner_display: Some corporate entity, author\n"+
+		"former_owner_t: Some corporate entity, author\n"+
 		"author_addl_display: Some corporate entity, former owner, author\n"+
 		"author_addl_t: Some corporate entity, former owner, author\n"+
 		"author_facet: Some corporate entity\n"+
@@ -453,9 +453,9 @@ public class TitleChangeTest extends DbBaseTest {
 		rec.dataFields.add(new DataField(3,5,"700",'1',' ',"‡6 700-05/$1 ‡a 向淑容, ‡4 fmo",true));
 		String expected =
 		"author_pers_roman_filing: xiang shurong\n"+
-		"former_owner_display: 向淑容 / Xiang, Shurong, former owner\n"+
+		"former_owner_display: 向淑容 / Xiang, Shurong\n"+
 		"former_owner_t: 向淑容\n"+
-		"former_owner_t: Xiang, Shurong, former owner\n";
+		"former_owner_t: Xiang, Shurong\n";
 		assertEquals(expected,this.gen.generateSolrFields(rec, config).toString());
 	}
 

--- a/src/test/java/edu/cornell/library/integration/metadata/generator/TitleChangeTest.java
+++ b/src/test/java/edu/cornell/library/integration/metadata/generator/TitleChangeTest.java
@@ -434,7 +434,6 @@ public class TitleChangeTest extends DbBaseTest {
 		rec.dataFields.add(new DataField(1,"710",'1',' ',"‡a Some corporate entity ‡e former owner, ‡e author."));
 		String expected =
 		"author_corp_roman_filing: some corporate entity\n"+
-		"former_owner_display: Some corporate entity, author\n"+
 		"former_owner_t: Some corporate entity, author\n"+
 		"author_addl_display: Some corporate entity, former owner, author\n"+
 		"author_addl_t: Some corporate entity, former owner, author\n"+

--- a/src/test/java/edu/cornell/library/integration/metadata/generator/TitleChangeTest.java
+++ b/src/test/java/edu/cornell/library/integration/metadata/generator/TitleChangeTest.java
@@ -28,11 +28,12 @@ public class TitleChangeTest extends DbBaseTest {
 	public void testSimple700() throws SQLException, IOException {
 		MarcRecord rec = new MarcRecord(MarcRecord.RecordType.BIBLIOGRAPHIC);
 		rec.dataFields.add(new DataField(1,"700",'1',' ',"‡a Smith, John, ‡d 1900-1999"));
-		String expected = "author_addl_display: Smith, John, 1900-1999\n"+
+		String expected =
+		"author_pers_roman_filing: smith john 1900 1999\n"+
+		"author_addl_display: Smith, John, 1900-1999\n"+
 		"author_addl_t: Smith, John, 1900-1999\n"+
 		"author_facet: Smith, John, 1900-1999\n"+
 		"author_pers_filing: smith john 1900 1999\n"+
-		"author_pers_roman_filing: smith john 1900 1999\n"+
 		"author_addl_json: {\"name1\":\"Smith, John, 1900-1999\",\"search1\":\"Smith, John, 1900-1999\","
 		+ "\"relator\":\"\",\"type\":\"Personal Name\",\"authorizedForm\":false}\n";
 		assertEquals( expected, this.gen.generateSolrFields(rec, config).toString() );
@@ -42,11 +43,12 @@ public class TitleChangeTest extends DbBaseTest {
 	public void testAuthorized700WithRelator() throws SQLException, IOException {
 		MarcRecord rec = new MarcRecord(MarcRecord.RecordType.BIBLIOGRAPHIC);
 		rec.dataFields.add(new DataField(1,"700",'1',' ',"‡a Ko, Dorothy, ‡d 1957- ‡e author."));
-		String expected = "author_addl_display: Ko, Dorothy, 1957- author\n"+
+		String expected =
+		"author_pers_roman_filing: ko dorothy 1957\n"+
+		"author_addl_display: Ko, Dorothy, 1957- author\n"+
 		"author_addl_t: Ko, Dorothy, 1957- author\n"+
 		"author_facet: Ko, Dorothy, 1957-\n"+
 		"author_pers_filing: ko dorothy 1957\n"+
-		"author_pers_roman_filing: ko dorothy 1957\n"+
 		"author_addl_json: {\"name1\":\"Ko, Dorothy, 1957- author\",\"search1\":\"Ko, Dorothy, 1957-\","
 		+ "\"relator\":\"author\",\"type\":\"Personal Name\",\"authorizedForm\":true}\n"+
 		"authority_author_t: Gao, Yanyi, 1957-\n"+
@@ -64,7 +66,8 @@ public class TitleChangeTest extends DbBaseTest {
 				+ " dances for peace. ‡p Half-wolf dances mad in moonlight."));
 		rec.dataFields.add(new DataField(3,"700",'1','2',"‡a Barber, Samuel, ‡d 1910-1981. ‡t Quartets, ‡m violins"
 				+ " (2), viola, cello, ‡n no. 1, op. 11, ‡r B minor. ‡p Adagio."));
-		String expected = "authortitle_facet: Sallinen, Aulis. | Vintern war hård; arranged\n"+
+		String expected =
+		"authortitle_facet: Sallinen, Aulis. | Vintern war hård; arranged\n"+
 		"authortitle_filing: sallinen aulis 0000 vintern war hard arranged\n"+
 		"author_addl_t: Sallinen, Aulis.\n"+
 		"author_facet: Sallinen, Aulis\n"+
@@ -104,23 +107,23 @@ public class TitleChangeTest extends DbBaseTest {
 		rec.dataFields.add(new DataField(3,5,"700",'1',' ',"‡6 700-05/$1 ‡a 向淑容, ‡e translator.",true));
 		rec.dataFields.add(new DataField(4,6,"700",'1',' ',"‡6 700-06/$1 ‡a 堯嘉寧, ‡e translator.",true));
 		String expected =
+		"author_pers_roman_filing: xiang shurong\n"+
 		"author_addl_display: 向淑容 / Xiang, Shurong, translator\n"+
 		"author_facet: 向淑容\n"+
 		"author_facet: Xiang, Shurong\n"+
 		"author_pers_filing: 向淑容\n"+
 		"author_pers_filing: xiang shurong\n"+
-		"author_pers_roman_filing: xiang shurong\n"+
 		"author_addl_t_cjk: 向淑容, translator\n"+
 		"author_addl_t: Xiang, Shurong, translator\n"+
 		"author_addl_json: {\"name1\":\"向淑容\",\"search1\":\"向淑容,\",\"name2\":\"Xiang, Shurong, translator\","
 		+ "\"search2\":\"Xiang, Shurong,\",\"relator\":\"translator\","
 		+ "\"type\":\"Personal Name\",\"authorizedForm\":false}\n"+
+		"author_pers_roman_filing: yao jianing\n"+
 		"author_addl_display: 堯嘉寧 / Yao, Jianing, translator\n"+
 		"author_facet: 堯嘉寧\n"+
 		"author_facet: Yao, Jianing\n"+
 		"author_pers_filing: 堯嘉寧\n"+
 		"author_pers_filing: yao jianing\n"+
-		"author_pers_roman_filing: yao jianing\n"+
 		"author_addl_t_cjk: 堯嘉寧, translator\n"+
 		"author_addl_t: Yao, Jianing, translator\n"+
 		"author_addl_json: {\"name1\":\"堯嘉寧\",\"search1\":\"堯嘉寧,\",\"name2\":\"Yao, Jianing, translator\","
@@ -135,12 +138,13 @@ public class TitleChangeTest extends DbBaseTest {
 		rec.dataFields.add(new DataField(1,6,"710",'2',' ',"‡6 880-06 ‡a Fa lü chu ban she. ‡b Fa gui chu ban"
 				+ " fen she, ‡e editor.",false));
 		rec.dataFields.add(new DataField(2,6,"710",'2',' ',"‡6 710-06/$1 ‡a 法律出版社. ‡b 法规出版分社, ‡e editor.",true));
-		String expected = "author_addl_display: 法律出版社. 法规出版分社 / Fa lü chu ban she. Fa gui chu ban fen she, editor\n"+
+		String expected =
+		"author_corp_roman_filing: fa lu chu ban she fa gui chu ban fen she\n"+
+		"author_addl_display: 法律出版社. 法规出版分社 / Fa lü chu ban she. Fa gui chu ban fen she, editor\n"+
 		"author_facet: 法律出版社. 法规出版分社\n"+
 		"author_facet: Fa lü chu ban she. Fa gui chu ban fen she\n"+
 		"author_corp_filing: 法律出版社 法规出版分社\n"+
 		"author_corp_filing: fa lu chu ban she fa gui chu ban fen she\n"+
-		"author_corp_roman_filing: fa lu chu ban she fa gui chu ban fen she\n"+
 		"author_addl_t_cjk: 法律出版社. 法规出版分社, editor\n"+
 		"author_addl_t: Fa lü chu ban she. Fa gui chu ban fen she, editor\n"+
 		"author_addl_json: {\"name1\":\"法律出版社. 法规出版分社\",\"search1\":\"法律出版社. 法规出版分社,\","
@@ -296,11 +300,11 @@ public class TitleChangeTest extends DbBaseTest {
 		rec.dataFields.add(new DataField(1,"711",'2','0',"‡a Institute on Religious Freedom ‡d (1966 : ‡c"
 				+ " North Aurora, Ill.)"));
 		String expected =
+		"author_event_roman_filing: institute on religious freedom\n"+
 		"author_addl_display: Institute on Religious Freedom (1966 : North Aurora, Ill.)\n"+
 		"author_addl_t: Institute on Religious Freedom (1966 : North Aurora, Ill.)\n"+
 		"author_facet: Institute on Religious Freedom\n"+
 		"author_event_filing: institute on religious freedom\n"+
-		"author_event_roman_filing: institute on religious freedom\n"+
 		"author_addl_json: {\"name1\":\"Institute on Religious Freedom (1966 : North Aurora, Ill.)\","
 		+ "\"search1\":\"Institute on Religious Freedom (1966 : North Aurora, Ill.)\",\"relator\":\"\","
 		+ "\"type\":\"Event\",\"authorizedForm\":false}\n";
@@ -412,4 +416,48 @@ public class TitleChangeTest extends DbBaseTest {
 		"title_uniform_t: Some title\n";
 		assertEquals(expected,this.gen.generateSolrFields(rec, config).toString());
 	}
+
+	@Test
+	public void formerOwner() throws SQLException, IOException {
+		MarcRecord rec = new MarcRecord(MarcRecord.RecordType.BIBLIOGRAPHIC);
+		rec.dataFields.add(new DataField(1,"700",'1',' ',"‡a Ammons, A. R., ‡d 1926-2001 ‡e former owner. ‡5 NIC"));
+		String expected =
+		"author_pers_roman_filing: ammons a r 1926 2001\n"+
+		"former_owner_display: Ammons, A. R., 1926-2001, former owner\n"+
+		"former_owner_t: Ammons, A. R., 1926-2001, former owner\n";
+		assertEquals(expected,this.gen.generateSolrFields(rec, config).toString());
+	}
+
+	@Test
+	public void formerOwnerAndAuthor() throws SQLException, IOException {
+		MarcRecord rec = new MarcRecord(MarcRecord.RecordType.BIBLIOGRAPHIC);
+		rec.dataFields.add(new DataField(1,"710",'1',' ',"‡a Some corporate entity ‡e former owner, ‡e author."));
+		String expected =
+		"author_corp_roman_filing: some corporate entity\n"+
+		"former_owner_display: Some corporate entity, former owner, author\n"+
+		"former_owner_t: Some corporate entity, former owner, author\n"+
+		"author_addl_display: Some corporate entity, former owner, author\n"+
+		"author_addl_t: Some corporate entity, former owner, author\n"+
+		"author_facet: Some corporate entity\n"+
+		"author_corp_filing: some corporate entity\n"+
+		"author_addl_json: {\"name1\":\"Some corporate entity, former owner, author\","
+		+ "\"search1\":\"Some corporate entity\",\"relator\":\"former owner, author\","
+		+ "\"type\":\"Corporate Name\",\"authorizedForm\":false}\n";
+		assertEquals(expected,this.gen.generateSolrFields(rec, config).toString());
+	}
+
+	@Test
+	public void nonRomanFormerOwner() throws SQLException, IOException {
+		MarcRecord rec = new MarcRecord(MarcRecord.RecordType.BIBLIOGRAPHIC);
+		rec.dataFields.add(new DataField(1,5,"700",'1',' ',"‡6 880-05 ‡a Xiang, Shurong, ‡4 fmo",false));
+		rec.dataFields.add(new DataField(3,5,"700",'1',' ',"‡6 700-05/$1 ‡a 向淑容, ‡4 fmo",true));
+		String expected =
+		"author_pers_roman_filing: xiang shurong\n"+
+		"former_owner_display: 向淑容 / Xiang, Shurong, former owner\n"+
+		"former_owner_t: 向淑容\n"+
+		"former_owner_t: Xiang, Shurong, former owner\n";
+		assertEquals(expected,this.gen.generateSolrFields(rec, config).toString());
+	}
+
+
 }


### PR DESCRIPTION
* If there are other relators than FMO, the field is now in BOTH places as they may also be a creator of the work.
* Also creating former_owner_display, though it's unclear whether we'll need it. DISCOVERYACCESS-641