### PR TITLE
Push 902 data to donor_t directly rather through copyField

### DIFF
--- a/solr/blacklightCore/conf/schema.xml
+++ b/solr/blacklightCore/conf/schema.xml
@@ -382,7 +382,6 @@
   <copyField source="id" dest="id_startsNum"/>
   <copyField source="donor_s" dest="donor_startsC"/>
   <copyField source="*_filing" dest="*_browse"/>
-  <copyField source="donor_display" dest="donor_t"/>
 
   <!-- spellcheck fields -->
   <!-- default spell check;  should match fields for default request handler -->

--- a/solr/blacklightCore/conf/solrconfig.xml
+++ b/solr/blacklightCore/conf/solrconfig.xml
@@ -752,10 +752,22 @@
       <str name="f.lc_callnum.pf"></str>
       <str name="f.lc_callnum_starts.qf"> lc_callnum_full lc_callnum_suffix </str>
 
-      <str name="f.donor.qf"> donor_s donor_t donor_tP donor_t_cjk </str>
-      <str name="f.donor.pf"> donor_s donor_t donor_tP donor_t_cjk </str>
-      <str name="f.donor_starts.qf"> donor_startsC donor_startsP donor_startsCJK </str>
-      <str name="f.donor_quoted.qf"> donor_s donor_unstemC donor_unstemP donor_t_cjk </str>
+      <str name="f.donor.qf">
+        donor_s donor_t donor_tP donor_t_cjk
+        former_owner_t former_owner_tP former_owner_t_cjk
+      </str>
+      <str name="f.donor.pf">
+        donor_s donor_t donor_tP donor_t_cjk
+        former_owner_t former_owner_tP former_owner_t_cjk
+      </str>
+      <str name="f.donor_starts.qf">
+        donor_startsC donor_startsP donor_startsCJK
+        former_owner_startsC former_owner_startsP former_owner_startsCJK
+      </str>
+      <str name="f.donor_quoted.qf">
+        donor_s donor_unstemC donor_unstemP donor_t_cjk
+        former_owner_unstemC former_owner_unstemP former_owner_t_cjk
+      </str>
 
       <str name="f.isbnissn.qf">
         isbn_t   isbn_tP   isbn_t_cjk
@@ -840,17 +852,17 @@
         online, 
         language_display, 
         pub_info_display,
-	pub_date_display,
+        pub_date_display,
         pub_date_facet,
-	url_access_display,
-	url_access_json,
-    	holdings_record_display,
-	item_record_display,
-	edition_display,
-	title_uniform_display,
-	oclc_id_display,
-	availability_json,
-	acquired_dt
+        url_access_display,
+        url_access_json,
+        holdings_record_display,
+        item_record_display,
+        edition_display,
+        title_uniform_display,
+        oclc_id_display,
+        availability_json,
+        acquired_dt
       </str>
      
       <str name="facet">true</str>

--- a/src/main/java/edu/cornell/library/integration/metadata/generator/SimpleProc.java
+++ b/src/main/java/edu/cornell/library/integration/metadata/generator/SimpleProc.java
@@ -16,7 +16,7 @@ import edu.cornell.library.integration.utilities.SolrFields.SolrField;
 public class SimpleProc implements SolrFieldGenerator {
 
 	@Override
-	public String getVersion() { return "1.6"; }
+	public String getVersion() { return "1.6.1"; }
 
 	@Override
 	public List<String> getHandledFields() {
@@ -231,7 +231,9 @@ public class SimpleProc implements SolrFieldGenerator {
 			case 902:
 				separateSubfields = true;
 				displayField = "donor_display";
+				searchField = "donor_t";
 				displaySubfields = "b";
+				searchSubfields = "ab";
 				break;
 			case 903:
 				searchField = "barcode_addl_t";

--- a/src/test/java/edu/cornell/library/integration/metadata/generator/SimpleProcTest.java
+++ b/src/test/java/edu/cornell/library/integration/metadata/generator/SimpleProcTest.java
@@ -188,7 +188,8 @@ public class SimpleProcTest {
 		rec.id = "7461";
 		assertEquals(
 				"donor_display: Goodkind\n" + 
-				"donor_display: Midland Friends\n",
+				"donor_display: Midland Friends\n" +
+				"donor_t: pfnd Goodkind Midland Friends\n",
 				this.gen.generateSolrFields(rec, null).toString());
 	}
 


### PR DESCRIPTION
Due to the intransitive nature of Solr copyField instruction, if we get the donor information into donor_t through one, we cannot then use any other copyField instructions to duplicate it from donor_t into other related search fields like the unstemmed and left-anchored variants.

DACCESS-189