### PR TITLE
Move bookplate links data to donor display

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,11 @@
         <directory>src/main/resources</directory>
       </resource>
     </resources>
+    <testResources>
+      <testResource>
+        <directory>src/test/resources</directory>
+      </testResource>
+    </testResources>
   </build>
   <dependencies>
     <dependency>

--- a/src/main/java/edu/cornell/library/integration/metadata/generator/URL.java
+++ b/src/main/java/edu/cornell/library/integration/metadata/generator/URL.java
@@ -36,7 +36,7 @@ public class URL implements SolrFieldGenerator {
 	private static ObjectMapper mapper = new ObjectMapper();
 
 	@Override
-	public String getVersion() { return "1.5"; }
+	public String getVersion() { return "1.6"; }
 
 	@Override
 	public List<String> getHandledFields() { return Arrays.asList("856","899","holdings"); }
@@ -274,11 +274,12 @@ public class URL implements SolrFieldGenerator {
 			String url = String.class.cast(link.get("url"));
 			String description = String.class.cast(link.get("description"));
 			if (relation.equals("bookplate")) {
-				if (link.containsKey("description"))
+				if (link.containsKey("description")) {
 					sfs.add( new SolrField ("donor_t", description ));
+					sfs.add( new SolrField ("donor_display", description ));
+				}
 				sfs.add( new SolrField ("donor_s", url.substring(url.lastIndexOf('/')+1)) );
-			}
-			if (relation.equals("access")) {
+			} else if (relation.equals("access")) {
 				link.remove("relation");
 				ByteArrayOutputStream jsonstream = new ByteArrayOutputStream();
 				mapper.writeValue(jsonstream, link);

--- a/src/test/java/edu/cornell/library/integration/metadata/generator/URLTest.java
+++ b/src/test/java/edu/cornell/library/integration/metadata/generator/URLTest.java
@@ -202,9 +202,8 @@ public class URLTest {
 
 		String expected =
 		"donor_t: From the Estate of Charles A. Leslie.\n"+
-		"donor_s: DNR00450\n"+
-		"url_bookplate_display: http://plates.library.cornell.edu/donor/DNR00450|From the Estate of Charles A. Leslie.\n"+
-		"notes_t: From the Estate of Charles A. Leslie.\n";
+		"donor_display: From the Estate of Charles A. Leslie.\n"+
+		"donor_s: DNR00450\n";
 
 		MarcRecord marc = new MarcRecord(MarcRecord.RecordType.BIBLIOGRAPHIC);
 		marc.folioHoldings = holdings;


### PR DESCRIPTION
The links are broken as their target site has been shut down, but the metadata is still important. DACCESS-219