### PR TITLE
Treat 6xx $2 ingest as source vocab unknown

### DIFF
--- a/src/main/java/edu/cornell/library/integration/metadata/generator/Subject.java
+++ b/src/main/java/edu/cornell/library/integration/metadata/generator/Subject.java
@@ -45,7 +45,7 @@ public class Subject implements SolrFieldGenerator {
 	private static List<String> unwantedFacetValues = Arrays.asList("Electronic books");
 
 	@Override
-	public String getVersion() { return "2.9"; }
+	public String getVersion() { return "2.10"; }
 
 	@Override
 	public List<String> getHandledFields() {
@@ -114,6 +114,7 @@ public class Subject implements SolrFieldGenerator {
 						case "rbmscv":  h.vocab = HeadingVocab.RBMSCV;  break;
 						case "zst":     h.vocab = HeadingVocab.ZST;     break;
 						case "local":   h.vocab = HeadingVocab.LOCAL;   break;
+						case "ingest":  h.vocab = HeadingVocab.UNK;     break;
 						default: h.vocab = HeadingVocab.OTHER;
 						}
 					}

--- a/src/test/java/edu/cornell/library/integration/metadata/generator/SubjectTest.java
+++ b/src/test/java/edu/cornell/library/integration/metadata/generator/SubjectTest.java
@@ -572,4 +572,47 @@ public class SubjectTest extends DbBaseTest {
 		assertEquals(expected,this.gen.generateSolrFields(rec, config).toString());
 	}
 
+	@Test
+	public void ingestVocabulary() throws SQLException, IOException {
+		MarcRecord rec = new MarcRecord(MarcRecord.RecordType.BIBLIOGRAPHIC);
+		rec.id = "15607152";
+		rec.dataFields.add(new DataField(2,"650",' ','7',"‡a Clothing industry--Study and teaching. ‡2 ingest"));
+		rec.dataFields.add(new DataField(7,"650",' ','0',"‡a Interior decoration ‡x Study and teaching."));
+		rec.dataFields.add(new DataField(10,"650",' ','7',"‡a Work environment -- Design. ‡2 ingest"));
+		String expected =
+		"subject_t: Clothing industry--Study and teaching\n"+
+		"subject_topic_facet: Clothing industry--Study and teaching\n"+
+		"subject_topic_filing: clothing industry 0000 study and teaching\n"+
+		"subject_topic_unk_facet: Clothing industry--Study and teaching\n"+
+		"subject_topic_unk_filing: clothing industry 0000 study and teaching\n"+
+
+		"subject_t: Interior decoration > Study and teaching\n"+
+		"subject_topic_facet: Interior decoration\n"+
+		"subject_topic_filing: interior decoration\n"+
+		"subject_topic_lc_facet: Interior decoration\n"+
+		"subject_topic_lc_filing: interior decoration\n"+
+		"subject_topic_facet: Interior decoration > Study and teaching\n"+
+		"subject_topic_filing: interior decoration 0000 study and teaching\n"+
+		"subject_topic_lc_facet: Interior decoration > Study and teaching\n"+
+		"subject_topic_lc_filing: interior decoration 0000 study and teaching\n"+
+
+		"subject_sub_lc_facet: Study and teaching\n"+
+		"subject_sub_lc_filing: study and teaching\n"+
+		"subject_t: Work environment -- Design\n"+
+		"subject_topic_facet: Work environment -- Design\n"+
+		"subject_topic_filing: work environment 0000 design\n"+
+		"subject_topic_unk_facet: Work environment -- Design\n"+
+		"subject_topic_unk_filing: work environment 0000 design\n"+
+
+		"subject_json: [{\"subject\":\"Clothing industry--Study and teaching.\",\"authorized\":false,"
+		+ "\"type\":\"Topical Term\"}]\n"+
+		"subject_json: [{\"subject\":\"Interior decoration\",\"authorized\":false,\"type\":\"Topical Term\"},"
+		+ "{\"subject\":\"Study and teaching.\",\"authorized\":false}]\n"+
+		"subject_json: [{\"subject\":\"Work environment -- Design.\",\"authorized\":false,\"type\":\"Topical Term\"}]\n"+
+		"subject_display: Clothing industry--Study and teaching\n"+
+		"subject_display: Interior decoration > Study and teaching\n"+
+		"subject_display: Work environment -- Design\n"+
+		"fast_b: false\n";
+		assertEquals(expected,this.gen.generateSolrFields(rec, config).toString());
+	}
 }


### PR DESCRIPTION
$2 ingest is a side effect of data corruption on import into ASpace that has made it into our Folio records.  These will need to be cleaned up individually in ASpace, a process with no known target date.  We're going to treat these in the meantime as having no identified source vocab, as "ingest" is not a vocabulary. The default previously was to assume the vocab in the $2 is a legitimate, if unfamiliar, vocabulary. DACCESS-328