### PR TITLE
Remove backslashes from search string everywhere

### DIFF
--- a/src/main/java/edu/cornell/library/integration/authority/Solr.java
+++ b/src/main/java/edu/cornell/library/integration/authority/Solr.java
@@ -140,7 +140,7 @@ public class Solr {
 
 	public static int querySolrForMatchingBibCount(HttpSolrClient solr, String field, String heading, boolean aspace) 
 			throws SolrServerException, IOException {
-		String query = field+":\""+heading.replaceAll("\"","'").replaceAll("\\\\$","")+'"';
+		String query = field+":\""+heading.replaceAll("\"","'").replaceAll("\\\\","")+'"';
 		SolrQuery q = new SolrQuery(query);
 		q.setRows(0);
 		q.setFields("instance_id","id");
@@ -159,7 +159,7 @@ public class Solr {
 		String normalizedHeading = getFilingForm( heading );
 		System.out.format("tabulating display versions for %s (%s)\n", field, facetField);
 
-		SolrQuery q = new SolrQuery(field+":\""+heading.replaceAll("\"","'").replaceAll("\\\\$","")+'"');
+		SolrQuery q = new SolrQuery(field+":\""+heading.replaceAll("\"","'").replaceAll("\\\\","")+'"');
 		q.setRows(10_000);
 		q.setFields(facetField,"id");
 		if (aspace) q.addFilterQuery("id_t:culaspace");


### PR DESCRIPTION
Backslash isn't part of a valid heading, and can potentially cause search failures.

org.apache.solr.search.SyntaxError: Non-hex character in Unicode escape sequence: k

error was returned when searching for
 \U+00d0\ukić, Bogomir, 1943-

Interestingly, Solr did not object to  \U+00d0 which is the encoding for capital eth (Đ), and part of the intended name, "Đukić". Removing the backslash will invalidate the Unicode escape character sequence for Solr, but that is already an incorrect encoding in this context. A search for this string without the backslashes will not find anything, but it's outside scope to attempt to correct corrupted values.