### PR TITLE
Make "notes" a qf, not a display field name

### DIFF
--- a/solr/blacklightCore/conf/schema.xml
+++ b/solr/blacklightCore/conf/schema.xml
@@ -280,7 +280,6 @@
     <field name="timestamp" type="date" indexed="true" stored="true" default="NOW" multiValued="false"/>
     <field name="_version_" type="long" indexed="true" stored="true" multiValued="false"/>
 
-    <field name="notes" type="text" indexed="false" stored="true" multiValued="true"/>
     <!-- fields used for back-end linking of license data for databases -->
     <field name="dbcode" type="string" indexed="false" stored="true" multiValued="true"/>
     <field name="providercode" type="string" indexed="false" stored="true" multiValued="true"/>

--- a/solr/blacklightCore/conf/solrconfig.xml
+++ b/solr/blacklightCore/conf/solrconfig.xml
@@ -832,8 +832,8 @@
       <str name="f.series_starts.qf">title_series_startsC^25 title_series_startsP^25 title_series_startsCJK</str>
       <str name="f.series_quoted.qf"> title_series_unstemC^25 title_series_unstemP^25 title_series_t_cjk</str>
 
- 	  <str name="f.notes_qf.qf">notes_t notes_tP notes_t_cjk</str>
- 	  <str name="f.notes_qf.pf">notes_t notes_tP notes_t_cjk</str>
+ 	  <str name="f.notes.qf">notes_t notes_tP notes_t_cjk</str>
+ 	  <str name="f.notes.pf">notes_t notes_tP notes_t_cjk</str>
  	  <str name="f.notes_starts.qf">notes_startsC notes_startsP notes_startsCJK</str>
  	  <str name="f.notes_quoted.qf">notes_unstemC notes_unstemP notes_t_cjk</str>
 

--- a/src/main/java/edu/cornell/library/integration/metadata/generator/SimpleProc.java
+++ b/src/main/java/edu/cornell/library/integration/metadata/generator/SimpleProc.java
@@ -37,7 +37,7 @@ public class SimpleProc implements SolrFieldGenerator {
 		boolean f300e = false;
 
 		for (DataField f : rec.matchSortAndFlattenDataFields()) {
-			String displayField = "notes";
+			String displayField = "notes_display";
 			String searchField = "notes_t";
 			String cjkSearchField = "notes_t_cjk";
 			String displaySubfields = null;

--- a/src/test/java/edu/cornell/library/integration/metadata/generator/SimpleProcTest.java
+++ b/src/test/java/edu/cornell/library/integration/metadata/generator/SimpleProcTest.java
@@ -141,9 +141,9 @@ public class SimpleProcTest {
 		rec.dataFields.add(new DataField(1,"500",' ',' ',"‡a Here's the first note."));
 		rec.dataFields.add(new DataField(2,"500",' ',' ',"‡a Here's the second note."));
 		String expected =
-		"notes: Here's the first note.\n"+
+		"notes_display: Here's the first note.\n"+
 		"notes_t: Here's the first note.\n"+
-		"notes: Here's the second note.\n"+
+		"notes_display: Here's the second note.\n"+
 		"notes_t: Here's the second note.\n";
 		assertEquals(expected,this.gen.generateSolrFields(rec, null).toString());
 	}
@@ -155,9 +155,9 @@ public class SimpleProcTest {
 		rec.dataFields.add(new DataField(2,1,"500",' ',' ',
 				"‡6 500-01/$1 ‡a Here's the non-Roman version of the note.", true));
 		String expected =
-		"notes: Here's the non-Roman version of the note.\n"+
+		"notes_display: Here's the non-Roman version of the note.\n"+
 		"notes_t_cjk: Here's the non-Roman version of the note.\n"+
-		"notes: Here's the main note.\n"+
+		"notes_display: Here's the main note.\n"+
 		"notes_t: Here's the main note.\n";
 		assertEquals(expected,this.gen.generateSolrFields(rec, null).toString());
 	}
@@ -172,13 +172,13 @@ public class SimpleProcTest {
 		rec.dataFields.add(new DataField(4,1,"500",' ',' ',
 				"‡6 500-01/$1 ‡a Here's the non-Roman version of the second note.", true));
 		String expected =
-		"notes: Here's the first note.\n"+
+		"notes_display: Here's the first note.\n"+
 		"notes_t: Here's the first note.\n"+
-		"notes: Here's the non-Roman version of the second note.\n"+
+		"notes_display: Here's the non-Roman version of the second note.\n"+
 		"notes_t_cjk: Here's the non-Roman version of the second note.\n"+
-		"notes: Here's the second note with non-Roman version.\n"+
+		"notes_display: Here's the second note with non-Roman version.\n"+
 		"notes_t: Here's the second note with non-Roman version.\n"+
-		"notes: Context note: Here's the third note.\n"+
+		"notes_display: Context note: Here's the third note.\n"+
 		"notes_t: Here's the third note.\n";
 		assertEquals(expected,this.gen.generateSolrFields(rec, null).toString());
 	}
@@ -228,7 +228,7 @@ public class SimpleProcTest {
 			rec.dataFields.add(new DataField(1,"511",'0',' ',
 					"‡a Fires of London ; the composer conducting."));
 			String expected =
-			"notes: Fires of London ; the composer conducting.\n" + 
+			"notes_display: Fires of London ; the composer conducting.\n" + 
 			"notes_t: Fires of London ; the composer conducting.\n";
 			assertEquals(expected,this.gen.generateSolrFields(rec, null).toString());
 		}


### PR DESCRIPTION
DACCESS-390
This change will require that submitted Solr documents not contain a field called notes as that will no longer be included in the schema.