### PR TITLE
Query Zephir on https

### DIFF
--- a/src/main/java/edu/cornell/library/integration/hathitrust/IdentifyChangedHathiBibs.java
+++ b/src/main/java/edu/cornell/library/integration/hathitrust/IdentifyChangedHathiBibs.java
@@ -255,7 +255,7 @@ public class IdentifyChangedHathiBibs {
 		return null;
 	}
 	private static MarcRecord getZephirRecord(String volumeId) throws IOException {
-		URL link = new URL("http://zephir.cdlib.org/api/item/"+volumeId+".json");
+		URL link = new URL("https://zephir.cdlib.org/api/item/"+volumeId+".json");
 		HttpURLConnection httpURLConnection = (HttpURLConnection) link.openConnection();
 		httpURLConnection.setRequestMethod("GET");
 		int responseCode = httpURLConnection.getResponseCode();


### PR DESCRIPTION
They appear to no longer support http. Using the correct protocol is easier than coding to support the 301 redirect. DACCESS-456