### PR TITLE
Make Hathifiles database update process more robust

### DIFF
--- a/src/main/java/edu/cornell/library/integration/hathitrust/BuildLocalHathiFilesDB.java
+++ b/src/main/java/edu/cornell/library/integration/hathitrust/BuildLocalHathiFilesDB.java
@@ -16,8 +16,6 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.text.SimpleDateFormat;
-import java.time.Duration;
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
@@ -191,7 +189,7 @@ public class BuildLocalHathiFilesDB {
 	public static void loadFileWithRetries(Connection hathidb, String url, String filename, List<String> prefixes)
 			throws IOException, SQLException, InterruptedException {
 		int[] startCount = {0};
-		int attemptLimit = 5;
+		int attemptLimit = 20;
 		boolean done = false;
 		for (int attempt = 1; !done && attempt <= attemptLimit; attempt++)  
 		try {
@@ -349,14 +347,12 @@ public class BuildLocalHathiFilesDB {
 	}
 
 	private static void executeSqlBatchStmts(int count, List<PreparedStatement> allStatements) throws SQLException {
-		Instant start = Instant.now();
 		List<String> resultCounts = new ArrayList<>();
 		for (PreparedStatement pstmt : allStatements) {
 			int[] results = pstmt.executeBatch();
 			resultCounts.add(commify(results.length)); //counting executions, not affected recs
 		}
-		System.out.format("%d seconds (%s) - position %s\n",
-				Duration.between(start, Instant.now()).getSeconds(),String.join(", ", resultCounts),commify(count));
+		System.out.format("Loaded records (%s) - up to position %s\n", String.join(", ", resultCounts),commify(count));
 	}
 
 	private static String commify (int number) {

--- a/src/main/java/edu/cornell/library/integration/hathitrust/BuildLocalHathiFilesDB.java
+++ b/src/main/java/edu/cornell/library/integration/hathitrust/BuildLocalHathiFilesDB.java
@@ -32,8 +32,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.zip.GZIPInputStream;
 
-import org.junit.jupiter.api.ClassOrderer.ClassName;
-
 import edu.cornell.library.integration.utilities.Config;
 
 public class BuildLocalHathiFilesDB {
@@ -381,5 +379,5 @@ public class BuildLocalHathiFilesDB {
 		for (String s : list.split(", *")) after.add(s);
 		return String.join(",",after);
 	}
-	private static final Logger LOGGER = Logger.getLogger( ClassName.class.getName() );
+	private static final Logger LOGGER = Logger.getLogger( "edu.cornell.library.integration.hathitrust.BuildLocalHathiFilesDB" );
 }

--- a/src/main/java/edu/cornell/library/integration/hathitrust/BuildLocalHathiFilesDB.java
+++ b/src/main/java/edu/cornell/library/integration/hathitrust/BuildLocalHathiFilesDB.java
@@ -291,11 +291,11 @@ public class BuildLocalHathiFilesDB {
 				}
 				count++;
 				if (count % batchSize == 0) {
-					System.out.format("count: %d, count %% batchSize: %d\n", count, count % batchSize);
+					System.out.format("count: %d, count %% %d: %d\n", count, batchSize, count % batchSize);
 					executeSqlBatchStmts(allStmts);
 				}
 			}
-			System.out.format("count: %d, count %% batchSize: %d\n", count, count % batchSize);
+			System.out.format("count: %d, count %% %d: %d\n", count, batchSize, count % batchSize);
 			executeSqlBatchStmts(allStmts);
 			for (PreparedStatement s : allStmts) s.close();
 			System.out.printf("%d bibs loaded from file %s\n", count,filename);


### PR DESCRIPTION
The new process detects known error conditions and will trigger retry/resume attempts up to 20 total attempts for a single file load. New or unexpected error conditions will still cause the job to crash. Also, batch database updates are meant to speed up the process, though the improvement is probably marginal with the DB on the same server as the running task.

DACCESS-573