### PR TITLE
Don't flip newer authorized headings to older ones

### DIFF
--- a/src/main/java/edu/cornell/library/integration/authority/ProcessAuthorityChangeFile.java
+++ b/src/main/java/edu/cornell/library/integration/authority/ProcessAuthorityChangeFile.java
@@ -136,12 +136,14 @@ public class ProcessAuthorityChangeFile {
 					String id = records.getString("id");
 
 					json.put("id", id);
-					json.put("inputFile", records.getString("updateFile"));
+					String updateFile = records.getString("updateFile");
+					json.put("inputFile", updateFile);
 					String mainEntry = records.getString("heading").replaceAll("\\\\$", "");
 					json.put("heading",mainEntry);
 					AuthoritySource vocab = AuthoritySource.byOrdinal(records.getInt("vocabulary"));
 
-					System.out.format("[%5d] %s: %s\n", records.getInt("positionInFile"), id, mainEntry);
+					System.out.format("[%s/%d] %s: %s\n",updateFile.replaceAll("[a-z]",""),
+							records.getInt("positionInFile"), id, mainEntry);
 
 					if ( records.getBoolean("undifferentiated") ) {
 						json.put("undifferentiated", true);

--- a/src/main/java/edu/cornell/library/integration/authority/ProcessAuthorityChangeFile.java
+++ b/src/main/java/edu/cornell/library/integration/authority/ProcessAuthorityChangeFile.java
@@ -425,8 +425,9 @@ public class ProcessAuthorityChangeFile {
 			}
 		}
 		try (PreparedStatement getOldRecordStmt = authority.prepareStatement(
-				"SELECT marcxml FROM voyagerAuthority WHERE id = ?")){
+				"SELECT marcxml FROM voyagerAuthority WHERE id = ? AND moddate < ?")){
 			getOldRecordStmt.setString(1, id);
+			getOldRecordStmt.setDate(2, moddate);
 			try ( ResultSet rs = getOldRecordStmt.executeQuery() ) {
 				while (rs.next()) {
 					String marc = rs.getString(1);


### PR DESCRIPTION
Don't include the version of an authority record exported from Voyager if it is newer than the version of the authority being evaluated to be potentially flipped to. 

FOL-252