### PR TITLE
Treat imported authority marc as marc-8 rather than utf-8

### DIFF
--- a/src/main/java/edu/cornell/library/integration/authority/LCAuthorityUpdateFile.java
+++ b/src/main/java/edu/cornell/library/integration/authority/LCAuthorityUpdateFile.java
@@ -50,6 +50,7 @@ public class LCAuthorityUpdateFile {
 				System.out.printf("Error parsing %s. Skipping the rest.\n", inputPath);
 				return records;
 			}
+			enforceMarc8Expectation(recordArray);
 			bytes = removeTopRecordFromArray( bytes, recordArray.length );
 			byte[] recordArrayUTF8 = convertMarc8RecordToUtf8( recordArray );
 			if ( recordArrayUTF8 == null ) {
@@ -68,7 +69,7 @@ public class LCAuthorityUpdateFile {
 
 		int count = 0;
 		try (PreparedStatement insertStmt = authorityDB.prepareStatement(
-				"INSERT INTO authorityUpdate"+
+				"REPLACE INTO authorityUpdate"+
 				"       (id,vocabulary,updateFile,positionInFile,changeType,"+
 				"        heading,headingType,linkedSubdivision,undifferentiated,"+
 				"        marc21,human,moddate) "+
@@ -106,6 +107,12 @@ public class LCAuthorityUpdateFile {
 		}
 	}
 
+	private static void enforceMarc8Expectation(byte[] recordBytes) {
+		// If we were ever to get authority MARC files coming through here that are actually Unicode and
+		// not just flagged as Unicde, we would need to remove or modify this.
+		char charSetByte = (char) recordBytes[9];
+		if (charSetByte == 'a') recordBytes[9] = ' ';
+	}
 
 	private static String extractLinkedSubdivision(MarcRecord r) {
 		for (DataField f : r.dataFields)

--- a/src/main/java/edu/cornell/library/integration/authority/LoadAuthorityUpdateFiles.java
+++ b/src/main/java/edu/cornell/library/integration/authority/LoadAuthorityUpdateFiles.java
@@ -1,0 +1,56 @@
+package edu.cornell.library.integration.authority;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.Map;
+
+import edu.cornell.library.integration.marc.MarcRecord;
+import edu.cornell.library.integration.utilities.Config;
+
+public class LoadAuthorityUpdateFiles {
+
+	public static void main(String[] args) throws SQLException, IOException {
+		List<String> requiredArgs = Config.getRequiredArgsForDB("Authority");
+		Config config = Config.loadConfig(requiredArgs);
+		Map<String, String> env = System.getenv();
+		String inputDir = env.get("input_directory");
+		String inputFiles = env.get("input_files");
+
+		if (inputDir == null || inputFiles == null) {
+			System.out.println("inputDir and inputFiles are required environment variables.");
+			System.exit(1);
+		}
+		String[] files = inputFiles.split(", *");
+		for (String file : files) {
+			File f = new File(inputDir,file);
+			if ( ! f.exists() ) {
+				System.out.println("File not found at "+f.getPath());
+				System.exit(2);
+			}
+		}
+
+		try (Connection authority = config.getDatabaseConnection("Authority");
+				PreparedStatement deleteTailStmt = authority.prepareStatement(
+						"DELETE FROM authorityUpdate WHERE updateFile = ? and positionInFile > ?")) {
+
+			for (String file : files) {
+				Path filePath = Paths.get(inputDir,file);
+				System.out.println(filePath.toString());
+				Map<MarcRecord,String> records = LCAuthorityUpdateFile.readFile(filePath);
+				LCAuthorityUpdateFile.pushRecordsToDatabase(authority, records, file);
+				deleteTailStmt.setString(1, file);
+				deleteTailStmt.setInt(2, records.size());
+				int deletedCount = deleteTailStmt.executeUpdate();
+				if (deletedCount > 0)
+					System.out.format("%d records deleted from authorityUpdate for %s past position %d.\n", deletedCount, file, records.size());
+			}
+		}
+	}
+
+}

--- a/src/main/java/edu/cornell/library/integration/authority/LoadAuthorityUpdateFiles.java
+++ b/src/main/java/edu/cornell/library/integration/authority/LoadAuthorityUpdateFiles.java
@@ -23,7 +23,7 @@ public class LoadAuthorityUpdateFiles {
 		String inputFiles = env.get("input_files");
 
 		if (inputDir == null || inputFiles == null) {
-			System.out.println("inputDir and inputFiles are required environment variables.");
+			System.out.println("input_directory and input_files are required environment variables.");
 			System.exit(1);
 		}
 		String[] files = inputFiles.split(", *");


### PR DESCRIPTION
We've been getting records with leader encoding suggesting that the character encoding is utf-8, while it is actually marc-8. Trusting the encoding and treating them as utf-8 results in character corruption. DACCESS-813