### PR TITLE
Update solrconfig.xml

### DIFF
--- a/solr/authoritiesCore/conf/solrconfig.xml
+++ b/solr/authoritiesCore/conf/solrconfig.xml
@@ -35,12 +35,9 @@
   <!-- query time configurations -->
   <query>
     <maxBooleanClauses>1024</maxBooleanClauses>
-    <filterCache class="solr.FastLRUCache"
-        size="512" initialSize="512" autowarmCount="128"/>
-    <queryResultCache class="solr.LRUCache"
-        size="512" initialSize="512" autowarmCount="32"/>
-    <documentCache class="solr.LRUCache"
-        size="512" initialSize="512" autowarmCount="0"/>
+    <filterCache class="solr.CaffeineCache" size="4096" autowarmCount="32"/>
+    <queryResultCache class="solr.CaffeineCache" size="1024" autowarmCount="0"/>
+    <documentCache class="solr.CaffeineCache" size="4096"/>
     <enableLazyFieldLoading>true</enableLazyFieldLoading>
     <queryResultWindowSize>50</queryResultWindowSize>
     <queryResultMaxDocsCached>200</queryResultMaxDocsCached>

--- a/solr/authoritiesCore/conf/solrconfig.xml
+++ b/solr/authoritiesCore/conf/solrconfig.xml
@@ -28,7 +28,7 @@
     </autoCommit>
 
     <autoSoftCommit> 
-      <maxTime>1000</maxTime> <!-- 1 second -->
+      <maxTime>10000</maxTime> <!-- 10 seconds -->
     </autoSoftCommit>
   </updateHandler>
 

--- a/solr/blacklightCore/conf/solrconfig.xml
+++ b/solr/blacklightCore/conf/solrconfig.xml
@@ -44,12 +44,9 @@
   <!-- query time configurations -->
   <query>
     <maxBooleanClauses>1024</maxBooleanClauses>
-    <filterCache class="solr.FastLRUCache"
-        size="512" initialSize="512" autowarmCount="128"/>
-    <queryResultCache class="solr.LRUCache"
-        size="512" initialSize="512" autowarmCount="32"/>
-    <documentCache class="solr.LRUCache"
-        size="512" initialSize="512" autowarmCount="0"/>
+    <filterCache class="solr.CaffeineCache" size="4096" autowarmCount="32"/>
+    <queryResultCache class="solr.CaffeineCache" size="1024" autowarmCount="0"/>
+    <documentCache class="solr.CaffeineCache" size="4096"/>
     <enableLazyFieldLoading>true</enableLazyFieldLoading>
     <queryResultWindowSize>50</queryResultWindowSize>
     <queryResultMaxDocsCached>200</queryResultMaxDocsCached>


### PR DESCRIPTION
Replace old LRUCache directives (removed in Solr 9.x) with new CaffeineCache directives. autowarmCounts are set very low, to assume autoSoftCommit times of 1 second; if this time increases, these autowarmCounts should be set higher.